### PR TITLE
[require-id-when-available] fix for inline fragments on interfaces

### DIFF
--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -67,7 +67,7 @@ const rule: GraphQLESLintRule<RequireIdWhenAvailableRuleConfig, true> = {
               //   parent.parent.kind === 'SelectionSet' &&
               //   !!parent.parent.selections.find(s => s.kind === 'Field' && s.name.value === fieldName);
 
-              if (!hasIdFieldInSelectionSet && !hasIdFieldInInterfaceSelectionSet) {
+              if (!hasIdFieldInSelectionSet) {
                 context.report({
                   loc: {
                     start: {

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -58,16 +58,16 @@ const rule: GraphQLESLintRule<RequireIdWhenAvailableRuleConfig, true> = {
                 s => s.kind === 'Field' && s.name.value === fieldName
               );
 
-              // // check if the parent selection set has the ID field in there
-              // const { parent } = node as any;
-              // const hasIdFieldInInterfaceSelectionSet =
-              //   parent &&
-              //   parent.kind === 'InlineFragment' &&
-              //   parent.parent &&
-              //   parent.parent.kind === 'SelectionSet' &&
-              //   !!parent.parent.selections.find(s => s.kind === 'Field' && s.name.value === fieldName);
+              // check if the parent selection set has the ID field in there
+              const { parent } = node as any;
+              const hasIdFieldInInterfaceSelectionSet =
+                parent &&
+                parent.kind === 'InlineFragment' &&
+                parent.parent &&
+                parent.parent.kind === 'SelectionSet' &&
+                !!parent.parent.selections.find(s => s.kind === 'Field' && s.name.value === fieldName);
 
-              if (!hasIdFieldInSelectionSet) {
+              if (!hasIdFieldInSelectionSet && !hasIdFieldInInterfaceSelectionSet) {
                 context.report({
                   loc: {
                     start: {

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -47,7 +47,6 @@ const rule: GraphQLESLintRule<RequireIdWhenAvailableRuleConfig, true> = {
         }
 
         const typeInfo = node.typeInfo();
-
         if (typeInfo && typeInfo.gqlType) {
           const rawType = getBaseType(typeInfo.gqlType);
           if (rawType instanceof GraphQLObjectType || rawType instanceof GraphQLInterfaceType) {
@@ -59,7 +58,16 @@ const rule: GraphQLESLintRule<RequireIdWhenAvailableRuleConfig, true> = {
                 s => s.kind === 'Field' && s.name.value === fieldName
               );
 
-              if (!hasIdFieldInSelectionSet) {
+              // // check if the parent selection set has the ID field in there
+              // const { parent } = node as any;
+              // const hasIdFieldInInterfaceSelectionSet =
+              //   parent &&
+              //   parent.kind === 'InlineFragment' &&
+              //   parent.parent &&
+              //   parent.parent.kind === 'SelectionSet' &&
+              //   !!parent.parent.selections.find(s => s.kind === 'Field' && s.name.value === fieldName);
+
+              if (!hasIdFieldInSelectionSet && !hasIdFieldInInterfaceSelectionSet) {
                 context.report({
                   loc: {
                     start: {

--- a/packages/plugin/tests/require-id-when-available.spec.ts
+++ b/packages/plugin/tests/require-id-when-available.spec.ts
@@ -5,10 +5,30 @@ const TEST_SCHEMA = /* GraphQL */ `
   type Query {
     hasId: HasId!
     noId: NoId!
+    vehicles: [Vehicle!]!
+    flying: [Flying!]!
   }
 
   type NoId {
     name: String!
+  }
+
+  interface Vehicle {
+    id: ID!
+  }
+
+  type Car implements Vehicle {
+    id: ID!
+    mileage: Int
+  }
+
+  interface Flying {
+    hasWings: Boolean!
+  }
+
+  type Bird implements Flying {
+    id: ID!
+    hasWings: Boolean!
   }
 
   type HasId {
@@ -24,6 +44,8 @@ ruleTester.runGraphQLTests('require-id-when-available', rule, {
   valid: [
     { ...WITH_SCHEMA, code: `query { noId { name } }` },
     { ...WITH_SCHEMA, code: `query { hasId { id name } }` },
+    { ...WITH_SCHEMA, code: `query { vehicles { id ...on Car { mileage } } }` },
+    { ...WITH_SCHEMA, code: `query { flying { ...on Bird { id } } }` },
     {
       ...WITH_SCHEMA,
       code: `query { hasId { name } }`,


### PR DESCRIPTION
With a schema like

```graphql
type Query {
  vehicles: [Vehicle!]!
}

interface Vehicle {
  id: ID!
}

type Car implements Vehicle {
  id: ID!
  mileage: Int
}
```

and a query like

```graphql
query { 
  vehicles { 
    id 
    ...on Car { 
      mileage 
    } 
  } 
}
```

I currently get a lint error because it'll say that `id` should also be present in the Car selection set.

This PR attempts to fix this issue. I had a problem with the types on `node.parent` which is why I typed it as `any`. Not quite sure what I should type it as to get it to work. 