### PR TITLE
input-name: Ignore non-Mutation fields.

### DIFF
--- a/.changeset/wise-paws-speak.md
+++ b/.changeset/wise-paws-speak.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Fix a bug in the input-name rule to make sure it only checks fields on the Mutation type

--- a/packages/plugin/tests/input-name.spec.ts
+++ b/packages/plugin/tests/input-name.spec.ts
@@ -23,6 +23,8 @@ ruleTester.runGraphQLTests('input-name', rule, {
       options: [{ checkInputType: true }],
     },
     'type Mutation { CreateMessage(input: String): String }',
+    'extend type Mutation { CreateMessage(input: String): String }',
+    'type Query { message(id: ID): Message }',
   ],
   invalid: [
     {
@@ -39,7 +41,7 @@ ruleTester.runGraphQLTests('input-name', rule, {
       errors: [{ message: 'InputType "String" name should be "SetMessageInput"' }],
     },
     {
-      code: 'type Mutaton { SetMessage(hello: SetMessageInput): String }',
+      code: 'type Mutation { SetMessage(hello: SetMessageInput): String }',
       options: [{ checkInputType: true }],
       errors: [{ message: 'Input "hello" should be called "input"' }],
     },


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-eslint/issues/75, which we also ran into.

This PR updates the `input-name` rule so it will ignore any fields that aren't on the `Mutation` type. This assumes that the schema is using the default `Mutation` type name. If we want to support a custom mutation type name we could add it as an option or alternatively parse for the `schema { mutation: MyMutationRootType }`

Thanks!