### PR TITLE
[naming-convention] Update property schema to accept objects. Add prefix and suffix option

### DIFF
--- a/.changeset/fuzzy-mice-return.md
+++ b/.changeset/fuzzy-mice-return.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+[naming-convention] Allow each definition to take either a strng or object. Object can take the following keys: style (naming style), prefix (value must have prefix) and suffix (value must have suffix)

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -37,27 +37,82 @@ The schema defines an array with all elements of the type `object`.
 
 The array object has the following properties:
 
-#### `FieldDefinition` (string,object)
+#### `FieldDefinition`
 
-#### `InputObjectTypeDefinition` (string,object)
+The object must be one of the following types:
 
-#### `EnumValueDefinition` (string,object)
+* `asString`
+* `asObject`
 
-#### `InputValueDefinition` (string,object)
+#### `InputObjectTypeDefinition`
 
-#### `ObjectTypeDefinition` (string,object)
+The object must be one of the following types:
 
-#### `InterfaceTypeDefinition` (string,object)
+* `asString`
+* `asObject`
 
-#### `EnumTypeDefinition` (string,object)
+#### `EnumValueDefinition`
 
-#### `UnionTypeDefinition` (string,object)
+The object must be one of the following types:
 
-#### `ScalarTypeDefinition` (string,object)
+* `asString`
+* `asObject`
 
-#### `OperationDefinition` (string,object)
+#### `InputValueDefinition`
 
-#### `FragmentDefinition` (string,object)
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `ObjectTypeDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `InterfaceTypeDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `EnumTypeDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `UnionTypeDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `ScalarTypeDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `OperationDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
+#### `FragmentDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
 
 #### `leadingUnderscore` (string, enum)
 
@@ -76,3 +131,30 @@ This element must be one of the following enum values:
 * `forbid`
 
 Default: `"forbid"`
+
+---
+
+# Sub Schemas
+
+The schema defines the following additional types:
+
+## `asString` (string)
+
+One of: `camelCase`, `PascalCase`, `snake_case`, `UPPER_CASE`
+
+## `asObject` (object)
+
+Properties of the `asObject` object:
+
+### `style` (string, enum)
+
+This element must be one of the following enum values:
+
+* `camelCase`
+* `PascalCase`
+* `snake_case`
+* `UPPER_CASE`
+
+### `prefix` (string)
+
+### `suffix` (string)

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -37,104 +37,27 @@ The schema defines an array with all elements of the type `object`.
 
 The array object has the following properties:
 
-#### `FieldDefinition` (string, enum)
+#### `FieldDefinition` (string,object)
 
-This element must be one of the following enum values:
+#### `InputObjectTypeDefinition` (string,object)
 
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
+#### `EnumValueDefinition` (string,object)
 
-#### `InputObjectTypeDefinition` (string, enum)
+#### `InputValueDefinition` (string,object)
 
-This element must be one of the following enum values:
+#### `ObjectTypeDefinition` (string,object)
 
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
+#### `InterfaceTypeDefinition` (string,object)
 
-#### `EnumValueDefinition` (string, enum)
+#### `EnumTypeDefinition` (string,object)
 
-This element must be one of the following enum values:
+#### `UnionTypeDefinition` (string,object)
 
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
+#### `ScalarTypeDefinition` (string,object)
 
-#### `InputValueDefinition` (string, enum)
+#### `OperationDefinition` (string,object)
 
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `ObjectTypeDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `InterfaceTypeDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `EnumTypeDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `UnionTypeDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `ScalarTypeDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `OperationDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
-
-#### `FragmentDefinition` (string, enum)
-
-This element must be one of the following enum values:
-
-* `camelCase`
-* `PascalCase`
-* `snake_case`
-* `UPPER_CASE`
+#### `FragmentDefinition` (string,object)
 
 #### `leadingUnderscore` (string, enum)
 

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -37,4 +37,20 @@ type someTypeName {
 
 ## Config Schema
 
-The schema defines the following properties:
+### (array)
+
+The schema defines an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+#### `on` (array)
+
+The object is an array with all elements of the type `string`.
+
+Additional restrictions:
+
+* Minimum items: `1`
+
+Additional restrictions:
+
+* Minimum items: `1`

--- a/docs/rules/require-id-when-available.md
+++ b/docs/rules/require-id-when-available.md
@@ -50,4 +50,12 @@ query user {
 
 ## Config Schema
 
-The schema defines the following properties:
+### (array)
+
+The schema defines an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+#### `fieldName` (string)
+
+Default: `"id"`

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -15,16 +15,20 @@ interface CheckNameFormatParams {
   style?: ValidNaming;
   leadingUnderscore: 'allow' | 'forbid';
   trailingUnderscore: 'allow' | 'forbid';
+  prefix: string;
   suffix: string;
 }
 function checkNameFormat(params: CheckNameFormatParams): { ok: false; errorMessage: string } | { ok: true } {
-  const { value, style, leadingUnderscore, trailingUnderscore, suffix } = params;
+  const { value, style, leadingUnderscore, trailingUnderscore, suffix, prefix } = params;
   let name = value;
   if (leadingUnderscore === 'allow') {
     [, name] = name.match(/^_*(.*)$/);
   }
   if (trailingUnderscore === 'allow') {
     name = name.replace(/_*$/, '');
+  }
+  if (prefix && !name.startsWith(prefix)) {
+    return { ok: false, errorMessage: '{{nodeType}} name "{{nodeName}}" should have "{{prefix}}" prefix' };
   }
   if (suffix && !name.endsWith(suffix)) {
     return { ok: false, errorMessage: '{{nodeType}} name "{{nodeName}}" should have "{{suffix}}" suffix' };
@@ -63,6 +67,7 @@ const schemaOption = {
 interface PropertySchema {
   style?: ValidNaming;
   suffix?: string;
+  prefix?: string;
 }
 
 type NamingConventionRuleConfig = [
@@ -150,12 +155,13 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       ...(context.options[0] || {}),
     };
 
-    const checkNode = (node, style, nodeType, suffix = '') => {
+    const checkNode = (node, style, nodeType, suffix = '', prefix = '') => {
       const result = checkNameFormat({
         value: node.value,
         style,
         leadingUnderscore: options.leadingUnderscore,
         trailingUnderscore: options.trailingUnderscore,
+        prefix: prefix,
         suffix: suffix,
       });
       if (result.ok === false) {
@@ -163,6 +169,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
           node,
           message: result.errorMessage,
           data: {
+            prefix: prefix,
             suffix: suffix,
             format: style,
             nodeType,
@@ -178,6 +185,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       }
       return {
         style: value,
+        prefix: '',
         suffix: '',
       };
     };
@@ -197,61 +205,61 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       ObjectTypeDefinition: node => {
         if (options.ObjectTypeDefinition) {
           const property = normalisePropertyOption(options.ObjectTypeDefinition);
-          checkNode(node.name, property.style, 'Type', property.suffix);
+          checkNode(node.name, property.style, 'Type', property.suffix, property.prefix);
         }
       },
       InterfaceTypeDefinition: node => {
         if (options.InterfaceTypeDefinition) {
           const property = normalisePropertyOption(options.InterfaceTypeDefinition);
-          checkNode(node.name, property.style, 'Interface', property.suffix);
+          checkNode(node.name, property.style, 'Interface', property.suffix, property.prefix);
         }
       },
       EnumTypeDefinition: node => {
         if (options.EnumTypeDefinition) {
           const property = normalisePropertyOption(options.EnumTypeDefinition);
-          checkNode(node.name, property.style, 'Enumerator', property.suffix);
+          checkNode(node.name, property.style, 'Enumerator', property.suffix, property.prefix);
         }
       },
       InputObjectTypeDefinition: node => {
         if (options.InputObjectTypeDefinition) {
           const property = normalisePropertyOption(options.InputObjectTypeDefinition);
-          checkNode(node.name, property.style, 'Input type', property.suffix);
+          checkNode(node.name, property.style, 'Input type', property.suffix, property.prefix);
         }
       },
       FieldDefinition: node => {
         if (options.FieldDefinition) {
           const property = normalisePropertyOption(options.FieldDefinition);
-          checkNode(node.name, property.style, 'Field', property.suffix);
+          checkNode(node.name, property.style, 'Field', property.suffix, property.prefix);
         }
       },
       EnumValueDefinition: node => {
         if (options.EnumValueDefinition) {
           const property = normalisePropertyOption(options.EnumValueDefinition);
-          checkNode(node.name, property.style, 'Enumeration value', property.suffix);
+          checkNode(node.name, property.style, 'Enumeration value', property.suffix, property.prefix);
         }
       },
       InputValueDefinition: node => {
         if (options.InputValueDefinition) {
           const property = normalisePropertyOption(options.InputValueDefinition);
-          checkNode(node.name, property.style, 'Input property', property.suffix);
+          checkNode(node.name, property.style, 'Input property', property.suffix, property.prefix);
         }
       },
       FragmentDefinition: node => {
         if (options.FragmentDefinition) {
           const property = normalisePropertyOption(options.FragmentDefinition);
-          checkNode(node.name, property.style, 'Fragment', property.suffix);
+          checkNode(node.name, property.style, 'Fragment', property.suffix, property.prefix);
         }
       },
       ScalarTypeDefinition: node => {
         if (options.ScalarTypeDefinition) {
           const property = normalisePropertyOption(options.ScalarTypeDefinition);
-          checkNode(node.name, property.style, 'Scalar', property.suffix);
+          checkNode(node.name, property.style, 'Scalar', property.suffix, property.prefix);
         }
       },
       UnionTypeDefinition: node => {
         if (options.UnionTypeDefinition) {
           const property = normalisePropertyOption(options.UnionTypeDefinition);
-          checkNode(node.name, property.style, 'Scalar', property.suffix);
+          checkNode(node.name, property.style, 'Scalar', property.suffix, property.prefix);
         }
       },
     };

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -63,6 +63,9 @@ const schemaOption = {
       type: 'string',
       enum: acceptedStyles,
     },
+    prefix: {
+      type: 'string',
+    },
     suffix: {
       type: 'string',
     },

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -57,19 +57,7 @@ function checkNameFormat(params: CheckNameFormatParams): { ok: false; errorMessa
 }
 
 const schemaOption = {
-  type: ['string', 'object'],
-  properties: {
-    style: {
-      type: 'string',
-      enum: acceptedStyles,
-    },
-    prefix: {
-      type: 'string',
-    },
-    suffix: {
-      type: 'string',
-    },
-  },
+  oneOf: [{ $ref: '#/definitions/asString' }, { $ref: '#/definitions/asObject' }],
 };
 
 interface PropertySchema {
@@ -127,21 +115,45 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
         },
       ],
     },
-    schema: [
-      {
+    schema: {
+      definitions: {
+        asString: {
+          type: 'string',
+          description: `One of: ${acceptedStyles.map(t => `\`${t}\``).join(', ')}`,
+          enum: acceptedStyles,
+        },
+        asObject: {
+          type: 'object',
+          properties: {
+            style: {
+              type: 'string',
+              enum: acceptedStyles,
+            },
+            prefix: {
+              type: 'string',
+            },
+            suffix: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'array',
+      items: {
         type: 'object',
         properties: {
-          [Kind.FIELD_DEFINITION]: schemaOption,
-          [Kind.INPUT_OBJECT_TYPE_DEFINITION]: schemaOption,
-          [Kind.ENUM_VALUE_DEFINITION]: schemaOption,
-          [Kind.INPUT_VALUE_DEFINITION]: schemaOption,
-          [Kind.OBJECT_TYPE_DEFINITION]: schemaOption,
-          [Kind.INTERFACE_TYPE_DEFINITION]: schemaOption,
-          [Kind.ENUM_TYPE_DEFINITION]: schemaOption,
-          [Kind.UNION_TYPE_DEFINITION]: schemaOption,
-          [Kind.SCALAR_TYPE_DEFINITION]: schemaOption,
-          [Kind.OPERATION_DEFINITION]: schemaOption,
-          [Kind.FRAGMENT_DEFINITION]: schemaOption,
+          [Kind.FIELD_DEFINITION as string]: schemaOption,
+          [Kind.INPUT_OBJECT_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.ENUM_VALUE_DEFINITION as string]: schemaOption,
+          [Kind.INPUT_VALUE_DEFINITION as string]: schemaOption,
+          [Kind.OBJECT_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.INTERFACE_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.ENUM_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.UNION_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.SCALAR_TYPE_DEFINITION as string]: schemaOption,
+          [Kind.OPERATION_DEFINITION as string]: schemaOption,
+          [Kind.FRAGMENT_DEFINITION as string]: schemaOption,
           leadingUnderscore: {
             type: 'string',
             enum: ['allow', 'forbid'],
@@ -154,7 +166,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
           },
         },
       },
-    ],
+    },
   },
   create(context) {
     const options: NamingConventionRuleConfig[number] = {

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -8,8 +8,13 @@ const formats = {
   UPPER_CASE: /^[A-Z_]*$/g,
 };
 
-type ValidNaming = 'camelCase' | 'PascalCase' | 'snake_case' | 'UPPER_CASE';
-const acceptedStyles: ValidNaming[] = ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'];
+const acceptedStyles: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'] = [
+  'camelCase',
+  'PascalCase',
+  'snake_case',
+  'UPPER_CASE',
+];
+type ValidNaming = typeof acceptedStyles[number];
 interface CheckNameFormatParams {
   value: string;
   style?: ValidNaming;

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -172,7 +172,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       }
     };
 
-    const convertToFinalPropertySchema = (value: ValidNaming | PropertySchema): PropertySchema => {
+    const normalisePropertyOption = (value: ValidNaming | PropertySchema): PropertySchema => {
       if (typeof value === 'object') {
         return value;
       }
@@ -196,61 +196,61 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       },
       ObjectTypeDefinition: node => {
         if (options.ObjectTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.ObjectTypeDefinition);
+          const property = normalisePropertyOption(options.ObjectTypeDefinition);
           checkNode(node.name, property.style, 'Type', property.suffix);
         }
       },
       InterfaceTypeDefinition: node => {
         if (options.InterfaceTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.InterfaceTypeDefinition);
+          const property = normalisePropertyOption(options.InterfaceTypeDefinition);
           checkNode(node.name, property.style, 'Interface', property.suffix);
         }
       },
       EnumTypeDefinition: node => {
         if (options.EnumTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.EnumTypeDefinition);
+          const property = normalisePropertyOption(options.EnumTypeDefinition);
           checkNode(node.name, property.style, 'Enumerator', property.suffix);
         }
       },
       InputObjectTypeDefinition: node => {
         if (options.InputObjectTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.InputObjectTypeDefinition);
+          const property = normalisePropertyOption(options.InputObjectTypeDefinition);
           checkNode(node.name, property.style, 'Input type', property.suffix);
         }
       },
       FieldDefinition: node => {
         if (options.FieldDefinition) {
-          const property = convertToFinalPropertySchema(options.FieldDefinition);
+          const property = normalisePropertyOption(options.FieldDefinition);
           checkNode(node.name, property.style, 'Field', property.suffix);
         }
       },
       EnumValueDefinition: node => {
         if (options.EnumValueDefinition) {
-          const property = convertToFinalPropertySchema(options.EnumValueDefinition);
+          const property = normalisePropertyOption(options.EnumValueDefinition);
           checkNode(node.name, property.style, 'Enumeration value', property.suffix);
         }
       },
       InputValueDefinition: node => {
         if (options.InputValueDefinition) {
-          const property = convertToFinalPropertySchema(options.InputValueDefinition);
+          const property = normalisePropertyOption(options.InputValueDefinition);
           checkNode(node.name, property.style, 'Input property', property.suffix);
         }
       },
       FragmentDefinition: node => {
         if (options.FragmentDefinition) {
-          const property = convertToFinalPropertySchema(options.FragmentDefinition);
+          const property = normalisePropertyOption(options.FragmentDefinition);
           checkNode(node.name, property.style, 'Fragment', property.suffix);
         }
       },
       ScalarTypeDefinition: node => {
         if (options.ScalarTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.ScalarTypeDefinition);
+          const property = normalisePropertyOption(options.ScalarTypeDefinition);
           checkNode(node.name, property.style, 'Scalar', property.suffix);
         }
       },
       UnionTypeDefinition: node => {
         if (options.UnionTypeDefinition) {
-          const property = convertToFinalPropertySchema(options.UnionTypeDefinition);
+          const property = normalisePropertyOption(options.UnionTypeDefinition);
           checkNode(node.name, property.style, 'Scalar', property.suffix);
         }
       },

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -50,7 +50,7 @@ function checkNameFormat(params: CheckNameFormatParams): { ok: false; errorMessa
 const schemaOption = {
   type: ['string', 'object'],
   properties: {
-    format: {
+    style: {
       type: 'string',
       enum: acceptedStyles,
     },
@@ -61,7 +61,7 @@ const schemaOption = {
 };
 
 interface PropertySchema {
-  format?: ValidNaming;
+  style?: ValidNaming;
   suffix?: string;
 }
 
@@ -177,7 +177,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
         return value;
       }
       return {
-        format: value,
+        style: value,
         suffix: '',
       };
     };
@@ -197,61 +197,61 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       ObjectTypeDefinition: node => {
         if (options.ObjectTypeDefinition) {
           const property = convertToFinalPropertySchema(options.ObjectTypeDefinition);
-          checkNode(node.name, property.format, 'Type', property.suffix);
+          checkNode(node.name, property.style, 'Type', property.suffix);
         }
       },
       InterfaceTypeDefinition: node => {
         if (options.InterfaceTypeDefinition) {
           const property = convertToFinalPropertySchema(options.InterfaceTypeDefinition);
-          checkNode(node.name, property.format, 'Interface', property.suffix);
+          checkNode(node.name, property.style, 'Interface', property.suffix);
         }
       },
       EnumTypeDefinition: node => {
         if (options.EnumTypeDefinition) {
           const property = convertToFinalPropertySchema(options.EnumTypeDefinition);
-          checkNode(node.name, property.format, 'Enumerator', property.suffix);
+          checkNode(node.name, property.style, 'Enumerator', property.suffix);
         }
       },
       InputObjectTypeDefinition: node => {
         if (options.InputObjectTypeDefinition) {
           const property = convertToFinalPropertySchema(options.InputObjectTypeDefinition);
-          checkNode(node.name, property.format, 'Input type', property.suffix);
+          checkNode(node.name, property.style, 'Input type', property.suffix);
         }
       },
       FieldDefinition: node => {
         if (options.FieldDefinition) {
           const property = convertToFinalPropertySchema(options.FieldDefinition);
-          checkNode(node.name, property.format, 'Field', property.suffix);
+          checkNode(node.name, property.style, 'Field', property.suffix);
         }
       },
       EnumValueDefinition: node => {
         if (options.EnumValueDefinition) {
           const property = convertToFinalPropertySchema(options.EnumValueDefinition);
-          checkNode(node.name, property.format, 'Enumeration value', property.suffix);
+          checkNode(node.name, property.style, 'Enumeration value', property.suffix);
         }
       },
       InputValueDefinition: node => {
         if (options.InputValueDefinition) {
           const property = convertToFinalPropertySchema(options.InputValueDefinition);
-          checkNode(node.name, property.format, 'Input property', property.suffix);
+          checkNode(node.name, property.style, 'Input property', property.suffix);
         }
       },
       FragmentDefinition: node => {
         if (options.FragmentDefinition) {
           const property = convertToFinalPropertySchema(options.FragmentDefinition);
-          checkNode(node.name, property.format, 'Fragment', property.suffix);
+          checkNode(node.name, property.style, 'Fragment', property.suffix);
         }
       },
       ScalarTypeDefinition: node => {
         if (options.ScalarTypeDefinition) {
           const property = convertToFinalPropertySchema(options.ScalarTypeDefinition);
-          checkNode(node.name, property.format, 'Scalar', property.suffix);
+          checkNode(node.name, property.style, 'Scalar', property.suffix);
         }
       },
       UnionTypeDefinition: node => {
         if (options.UnionTypeDefinition) {
           const property = convertToFinalPropertySchema(options.UnionTypeDefinition);
-          checkNode(node.name, property.format, 'Scalar', property.suffix);
+          checkNode(node.name, property.style, 'Scalar', property.suffix);
         }
       },
     };

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -79,9 +79,9 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       code: 'type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }',
       options: [
         {
-          ObjectTypeDefinition: { format: 'PascalCase' },
-          FieldDefinition: { format: 'camelCase', suffix: 'Field' },
-          EnumValueDefinition: { format: 'UPPER_CASE', suffix: '' },
+          ObjectTypeDefinition: { style: 'PascalCase' },
+          FieldDefinition: { style: 'camelCase', suffix: 'Field' },
+          EnumValueDefinition: { style: 'UPPER_CASE', suffix: '' },
         },
       ],
     },
@@ -154,9 +154,9 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       code: 'type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }',
       options: [
         {
-          ObjectTypeDefinition: { format: 'camelCase' },
-          FieldDefinition: { format: 'camelCase', suffix: 'AAA' },
-          EnumValueDefinition: { format: 'camelCase', suffix: 'ENUM' },
+          ObjectTypeDefinition: { style: 'camelCase' },
+          FieldDefinition: { style: 'camelCase', suffix: 'AAA' },
+          EnumValueDefinition: { style: 'camelCase', suffix: 'ENUM' },
         },
       ],
       errors: [

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -91,7 +91,7 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         {
           ObjectTypeDefinition: { style: 'PascalCase' },
           FieldDefinition: { style: 'camelCase', prefix: 'field' },
-          EnumValueDefinition: { style: 'UPPER_CASE', prefix: 'ENUM' },
+          EnumValueDefinition: { style: 'UPPER_CASE', prefix: '' },
         },
       ],
     },

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -75,6 +75,16 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       code:
         'input test { item: String } enum B { Test } interface A { i: String } fragment PictureFragment on Picture { uri } scalar Hello',
     },
+    {
+      code: 'type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }',
+      options: [
+        {
+          ObjectTypeDefinition: { format: 'PascalCase' },
+          FieldDefinition: { format: 'camelCase', suffix: 'Field' },
+          EnumValueDefinition: { format: 'UPPER_CASE', suffix: '' },
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -138,6 +148,22 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         { message: 'Input type name "test" should be in PascalCase format' },
         { message: 'Input property name "_Value" should be in snake_case format' },
         { message: 'Leading underscores are not allowed' },
+      ],
+    },
+    {
+      code: 'type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }',
+      options: [
+        {
+          ObjectTypeDefinition: { format: 'camelCase' },
+          FieldDefinition: { format: 'camelCase', suffix: 'AAA' },
+          EnumValueDefinition: { format: 'camelCase', suffix: 'ENUM' },
+        },
+      ],
+      errors: [
+        { message: 'Type name "TypeOne" should be in camelCase format' },
+        { message: 'Field name "aField" should have "AAA" suffix' },
+        { message: 'Enumeration value name "VALUE_ONE" should have "ENUM" suffix' },
+        { message: 'Enumeration value name "VALUE_TWO" should have "ENUM" suffix' },
       ],
     },
   ],

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -85,6 +85,16 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: 'type One { fieldA: String } enum Z { ENUM_VALUE_ONE ENUM_VALUE_TWO }',
+      options: [
+        {
+          ObjectTypeDefinition: { style: 'PascalCase' },
+          FieldDefinition: { style: 'camelCase', prefix: 'field' },
+          EnumValueDefinition: { style: 'UPPER_CASE', prefix: 'ENUM' },
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -164,6 +174,21 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         { message: 'Field name "aField" should have "AAA" suffix' },
         { message: 'Enumeration value name "VALUE_ONE" should have "ENUM" suffix' },
         { message: 'Enumeration value name "VALUE_TWO" should have "ENUM" suffix' },
+      ],
+    },
+    {
+      code: 'type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }',
+      options: [
+        {
+          ObjectTypeDefinition: { style: 'PascalCase' },
+          FieldDefinition: { style: 'camelCase', prefix: 'Field' },
+          EnumValueDefinition: { style: 'UPPER_CASE', prefix: 'ENUM' },
+        },
+      ],
+      errors: [
+        { message: 'Field name "aField" should have "Field" prefix' },
+        { message: 'Enumeration value name "A_ENUM_VALUE_ONE" should have "ENUM" prefix' },
+        { message: 'Enumeration value name "VALUE_TWO" should have "ENUM" prefix' },
       ],
     },
   ],

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -58,15 +58,18 @@ async function main() {
 
     if (rule.meta?.schema) {
       blocks.push(BR, `## Config Schema`, BR);
+      let jsonSchema = rule.meta.schema;
       const isArray = Array.isArray(rule.meta.schema);
 
-      const patchedSchema = {
-        type: isArray ? 'array' : 'object',
-        ...(isArray ? { items: rule.meta.schema[0] } : rule.meta.schema[0]),
-        $schema: 'http://json-schema.org/draft-04/schema',
-      };
+      if (isArray) {
+        jsonSchema = {
+          type: isArray ? 'array' : 'object',
+          ...(isArray ? { items: rule.meta.schema[0] } : rule.meta.schema[0]),
+          $schema: 'http://json-schema.org/draft-04/schema',
+        };
+      }
 
-      blocks.push(md(patchedSchema, '##'));
+      blocks.push(md(jsonSchema, '##'));
     }
 
     return {


### PR DESCRIPTION
To make this rule more flexible, it needs to be able to take an object as well as format style string. For example, we might want to check whether a field has a certain suffix. More details: https://github.com/dotansimha/graphql-eslint/issues/195

The config is normalized into an object before passing into the validation function.

Note that we can no longer rely on the default enum check because it also tries to validate that an object is part of the enum. Therefore, the validation function needs to check the format enums now.

Also, added a suffix option. The targeted property must have the correct suffix or it will error.

### TODO

- [x] Update docs ?