### PR TITLE
Fix processor compatibility with other plugins

### DIFF
--- a/.changeset/shaggy-planets-travel.md
+++ b/.changeset/shaggy-planets-travel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Fix processor compatibility with other plugins


### PR DESCRIPTION
This is PR aims to extends compatibility of this plugin with eslint ecosystem

Related #88 

This proposal comes from https://github.com/dotansimha/graphql-eslint/issues/88#issuecomment-722531443 @lavigneer's comment.

The workaround plays with relative path in the block filename containing original source text. It allows other plugins to resolve original source file on the filesystem.