### PR TITLE
Add code file loader when using graphql-config

### DIFF
--- a/.changeset/tame-onions-wink.md
+++ b/.changeset/tame-onions-wink.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+Added code file compatibility for graphql-config projects

--- a/examples/graphql-config-code-file/.eslintrc.json
+++ b/examples/graphql-config-code-file/.eslintrc.json
@@ -1,0 +1,19 @@
+{  
+  "processor": "@graphql-eslint/graphql",
+  "overrides": [
+    {
+      "files": ["*.graphql"],
+      "parser": "@graphql-eslint/eslint-plugin",
+      "parserOptions": {
+        "schema": "./**/schema.graphql"
+      },
+      "plugins": ["@graphql-eslint"],
+      "rules": {
+        "@graphql-eslint/require-id-when-available": "warn",
+        "@graphql-eslint/no-anonymous-operations": "warn",
+        "@graphql-eslint/no-operation-name-suffix": "error",
+        "@graphql-eslint/validate-against-schema": "error"
+      }
+    }
+  ]
+}

--- a/examples/graphql-config-code-file/graphql.config.yml
+++ b/examples/graphql-config-code-file/graphql.config.yml
@@ -1,0 +1,2 @@
+schema: "./**/schema.graphql"
+documents: "./query.js"

--- a/examples/graphql-config-code-file/package.json
+++ b/examples/graphql-config-code-file/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@graphql-eslint/example-graphql-config--code-file",
+  "private": true,
+  "version": "0.0.1",
+  "repository": "https://github.com/dotansimha/graphql-eslint",
+  "author": "Dotan Simha <dotansimha@gmail.com>",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint --ext graphql,js ."
+  },
+  "dependencies": {
+    "@graphql-eslint/eslint-plugin": "0.6.0",
+    "eslint": "7.14.0",
+    "graphql": "15.4.0",
+    "graphql-tag": "^2.11.0",
+    "typescript": "4.1.2"
+  }
+}

--- a/examples/graphql-config-code-file/query.js
+++ b/examples/graphql-config-code-file/query.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+const myQuery = gql`
+  query {
+    user {
+      name
+    }
+  }
+`;

--- a/examples/graphql-config-code-file/schema.graphql
+++ b/examples/graphql-config-code-file/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  user: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/packages/plugin/src/parser.ts
+++ b/packages/plugin/src/parser.ts
@@ -13,8 +13,8 @@ export function parse(code: string, options?: ParserOptions): Linter.ESLintParse
 }
 
 const addCodeFileLoaderExtension: GraphQLExtensionDeclaration = (api) => {
-  schemaLoaders().forEach(loader => api.loaders.schema.register(loader))
-  operationsLoaders().forEach(loader => api.loaders.documents.register(loader))
+  schemaLoaders.forEach(loader => api.loaders.schema.register(loader))
+  operationsLoaders.forEach(loader => api.loaders.documents.register(loader))
   return { name: 'graphql-eslint-loaders' }
 }
 

--- a/packages/plugin/src/schema.ts
+++ b/packages/plugin/src/schema.ts
@@ -2,12 +2,28 @@ import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
 import { JsonFileLoader } from '@graphql-tools/json-file-loader';
 import { loadSchemaSync } from '@graphql-tools/load';
 import { UrlLoader } from '@graphql-tools/url-loader';
+import { Loader, SingleFileOptions } from '@graphql-tools/utils';
 import { buildSchema, GraphQLSchema } from 'graphql';
 import { GraphQLConfig } from 'graphql-config';
 import { dirname } from 'path';
 import { ParserOptions } from './types';
 
 const schemaCache: Map<string, GraphQLSchema> = new Map();
+
+export const schemaLoaders = (): Loader<string, SingleFileOptions>[] => [
+  {
+    loaderId: () => 'direct-string',
+    canLoad: async () => false,
+    load: async () => null,
+    canLoadSync: pointer => typeof pointer === 'string' && pointer.includes('type '),
+    loadSync: pointer => ({
+      schema: buildSchema(pointer),
+    }),
+  },
+  new GraphQLFileLoader(),
+  new JsonFileLoader(),
+  new UrlLoader(),
+]
 
 export function getSchema(options: ParserOptions, gqlConfig: GraphQLConfig): GraphQLSchema | null {
   let schema: GraphQLSchema | null = null;
@@ -44,20 +60,7 @@ export function getSchema(options: ParserOptions, gqlConfig: GraphQLConfig): Gra
         schema = loadSchemaSync(options.schema, {
           ...(options.schemaOptions || {}),
           assumeValidSDL: true,
-          loaders: [
-            {
-              loaderId: () => 'direct-string',
-              canLoad: async () => false,
-              load: async () => null,
-              canLoadSync: pointer => typeof pointer === 'string' && pointer.includes('type '),
-              loadSync: pointer => ({
-                schema: buildSchema(pointer),
-              }),
-            },
-            new GraphQLFileLoader(),
-            new JsonFileLoader(),
-            new UrlLoader(),
-          ],
+          loaders: schemaLoaders(),
         });
         schemaCache.set(schemaKey, schema);
       } catch (e) {

--- a/packages/plugin/src/schema.ts
+++ b/packages/plugin/src/schema.ts
@@ -10,7 +10,7 @@ import { ParserOptions } from './types';
 
 const schemaCache: Map<string, GraphQLSchema> = new Map();
 
-export const schemaLoaders = (): Loader<string, SingleFileOptions>[] => [
+export const schemaLoaders: Loader<string, SingleFileOptions>[] = [
   {
     loaderId: () => 'direct-string',
     canLoad: async () => false,
@@ -60,7 +60,7 @@ export function getSchema(options: ParserOptions, gqlConfig: GraphQLConfig): Gra
         schema = loadSchemaSync(options.schema, {
           ...(options.schemaOptions || {}),
           assumeValidSDL: true,
-          loaders: schemaLoaders(),
+          loaders: schemaLoaders,
         });
         schemaCache.set(schemaKey, schema);
       } catch (e) {

--- a/packages/plugin/src/sibling-operations.ts
+++ b/packages/plugin/src/sibling-operations.ts
@@ -1,7 +1,7 @@
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { loadDocumentsSync } from '@graphql-tools/load';
-import { Source } from '@graphql-tools/utils';
+import { Loader, SingleFileOptions, Source } from '@graphql-tools/utils';
 import {
   FragmentDefinitionNode,
   FragmentSpreadNode,
@@ -17,6 +17,20 @@ import { dirname, join } from 'path';
 
 export type FragmentSource = { filePath: string; document: FragmentDefinitionNode };
 export type OperationSource = { filePath: string; document: OperationDefinitionNode };
+
+export const operationsLoaders = (): Loader<string, SingleFileOptions>[] => [
+  new GraphQLFileLoader(),
+  new CodeFileLoader(),
+  {
+    loaderId: () => 'direct-string',
+    canLoad: async () => false,
+    load: async () => null,
+    canLoadSync: pointer => typeof pointer === 'string' && pointer.includes('type '),
+    loadSync: pointer => ({
+      document: parse(pointer),
+    }),
+  },
+]
 
 export type SiblingOperations = {
   available: boolean;
@@ -35,19 +49,7 @@ export type SiblingOperations = {
 function loadSiblings(baseDir: string, loadPaths: string[]): Source[] {
   return loadDocumentsSync(loadPaths, {
     cwd: baseDir,
-    loaders: [
-      new GraphQLFileLoader(),
-      new CodeFileLoader(),
-      {
-        loaderId: () => 'direct-string',
-        canLoad: async () => false,
-        load: async () => null,
-        canLoadSync: pointer => typeof pointer === 'string' && pointer.includes('type '),
-        loadSync: pointer => ({
-          document: parse(pointer),
-        }),
-      },
-    ],
+    loaders: operationsLoaders(),
   }).map(r => ({ ...r, location: join(baseDir, r.location) }));
 }
 

--- a/packages/plugin/src/sibling-operations.ts
+++ b/packages/plugin/src/sibling-operations.ts
@@ -18,7 +18,7 @@ import { dirname, join } from 'path';
 export type FragmentSource = { filePath: string; document: FragmentDefinitionNode };
 export type OperationSource = { filePath: string; document: OperationDefinitionNode };
 
-export const operationsLoaders = (): Loader<string, SingleFileOptions>[] => [
+export const operationsLoaders: Loader<string, SingleFileOptions>[] = [
   new GraphQLFileLoader(),
   new CodeFileLoader(),
   {
@@ -49,7 +49,7 @@ export type SiblingOperations = {
 function loadSiblings(baseDir: string, loadPaths: string[]): Source[] {
   return loadDocumentsSync(loadPaths, {
     cwd: baseDir,
-    loaders: operationsLoaders(),
+    loaders: operationsLoaders,
   }).map(r => ({ ...r, location: join(baseDir, r.location) }));
 }
 


### PR DESCRIPTION
# Purpose

This PR aims to unify the loaders available when using eslint config and `graphql-config`.

Related #232

## Context

Today, `graphql-eslint` is loading schema and operations via `graphql-config` if available and not disable. Otherwise, it uses directly `graphql-tools` and `parserOptions` of eslint configuration file.

## Problem

When parsing schema and operations directly via `graphql-tools`, we use some loaders such as `CodeFileLoader` which allow to parse graphql inside JavaScript and TypeScript files.

But when we use `graphql-config`, this loaders are not used by default.

This lead to projects not lintable if used with graphql-config.

## Solution

My proposition is to create a custom extension for `graphql-config` which allows us to add the same loaders than when we directly use `graphql-tools`.

We don't have to mind if some loaders are already setup by default, `graphql-config` has a check to not register the same loader multiple times.

## What have been changed

I have made a little refactoring: I put loaders lists for schemas and documents in functions to be reusable. I have then used this functions in place of the loaders lists in `loadSiblings` and `loadSchemas`.

I have then created a custom `graphql-config` extension which also use the loaders list and register every loaders in `graphql-config` loaders registry. I didn't found a better way to add custom loaders to `graphql-config` and after some search it seems to be the recommended way.