### PR TITLE
Add cache for graphql-config loading

### DIFF
--- a/.changeset/cool-frogs-kiss.md
+++ b/.changeset/cool-frogs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Load graphql config file only once

--- a/packages/plugin/src/graphql-config.ts
+++ b/packages/plugin/src/graphql-config.ts
@@ -1,0 +1,25 @@
+import { GraphQLConfig, GraphQLExtensionDeclaration, loadConfigSync } from 'graphql-config';
+import { schemaLoaders } from './schema';
+import { operationsLoaders } from './sibling-operations';
+import { ParserOptions } from './types';
+
+export function loadGraphqlConfig(options: ParserOptions): GraphQLConfig | null {
+  if (options?.skipGraphQLConfig) return null;
+  if (!graphqlConfig) {
+    graphqlConfig = loadConfigSync({
+      throwOnEmpty: false,
+      throwOnMissing: false,
+      extensions: [addCodeFileLoaderExtension],
+    });
+  }
+
+  return graphqlConfig;
+}
+
+let graphqlConfig: GraphQLConfig | null;
+
+const addCodeFileLoaderExtension: GraphQLExtensionDeclaration = api => {
+  schemaLoaders.forEach(loader => api.loaders.schema.register(loader));
+  operationsLoaders.forEach(loader => api.loaders.documents.register(loader));
+  return { name: 'graphql-eslint-loaders' };
+};

--- a/packages/plugin/src/parser.ts
+++ b/packages/plugin/src/parser.ts
@@ -4,29 +4,16 @@ import { GraphQLError, TypeInfo } from 'graphql';
 import { Linter } from 'eslint';
 import { GraphQLESLintParseResult, ParserOptions } from './types';
 import { extractTokens } from './utils';
-import { getSchema, schemaLoaders } from './schema';
-import { getSiblingOperations, operationsLoaders } from './sibling-operations';
-import { loadConfigSync, GraphQLConfig, GraphQLExtensionDeclaration } from 'graphql-config';
+import { getSchema } from './schema';
+import { getSiblingOperations } from './sibling-operations';
+import { loadGraphqlConfig } from './graphql-config';
 
 export function parse(code: string, options?: ParserOptions): Linter.ESLintParseResult['ast'] {
   return parseForESLint(code, options).ast;
 }
 
-const addCodeFileLoaderExtension: GraphQLExtensionDeclaration = api => {
-  schemaLoaders.forEach(loader => api.loaders.schema.register(loader));
-  operationsLoaders.forEach(loader => api.loaders.documents.register(loader));
-  return { name: 'graphql-eslint-loaders' };
-};
-
 export function parseForESLint(code: string, options?: ParserOptions): GraphQLESLintParseResult {
-  const gqlConfig: GraphQLConfig | null = options?.skipGraphQLConfig
-    ? null
-    : loadConfigSync({
-        throwOnEmpty: false,
-        throwOnMissing: false,
-        extensions: [addCodeFileLoaderExtension],
-      });
-
+  const gqlConfig = loadGraphqlConfig(options);
   const schema = getSchema(options, gqlConfig);
   const siblingOperations = getSiblingOperations(options, gqlConfig);
   const parserServices = {

--- a/packages/plugin/src/schema.ts
+++ b/packages/plugin/src/schema.ts
@@ -23,26 +23,24 @@ export const schemaLoaders: Loader<string, SingleFileOptions>[] = [
   new GraphQLFileLoader(),
   new JsonFileLoader(),
   new UrlLoader(),
-]
+];
 
 export function getSchema(options: ParserOptions, gqlConfig: GraphQLConfig): GraphQLSchema | null {
   let schema: GraphQLSchema | null = null;
 
   // We first try to use graphql-config for loading the schema, based on the type of the file,
   // We are using the directory of the file as the key for the schema caching, to avoid reloading of the schema.
-  if (options && options.filePath && !options.skipGraphQLConfig) {
+  if (gqlConfig && options?.filePath) {
     const fileDir = dirname(options.filePath);
 
     if (schemaCache.has(fileDir)) {
       schema = schemaCache.get(fileDir);
     } else {
-      if (gqlConfig) {
-        const projectForFile = gqlConfig.getProjectForFile(options.filePath);
+      const projectForFile = gqlConfig.getProjectForFile(options.filePath);
 
-        if (projectForFile) {
-          schema = projectForFile.getSchemaSync();
-          schemaCache.set(fileDir, schema);
-        }
+      if (projectForFile) {
+        schema = projectForFile.getSchemaSync();
+        schemaCache.set(fileDir, schema);
       }
     }
   }
@@ -50,7 +48,7 @@ export function getSchema(options: ParserOptions, gqlConfig: GraphQLConfig): Gra
   // If schema was not loaded yet, and user configured it in the parserConfig, we can try to load it,
   // In this case, the cache key is the path for the schema. This is needed in order to allow separate
   // configurations for different file paths (a very edgey case).
-  if (options && !schema && options.schema) {
+  if (!schema && options?.schema) {
     const schemaKey = Array.isArray(options.schema) ? options.schema.join(',') : options.schema;
 
     if (schemaCache.has(schemaKey)) {

--- a/packages/plugin/src/sibling-operations.ts
+++ b/packages/plugin/src/sibling-operations.ts
@@ -30,7 +30,7 @@ export const operationsLoaders: Loader<string, SingleFileOptions>[] = [
       document: parse(pointer),
     }),
   },
-]
+];
 
 export type SiblingOperations = {
   available: boolean;
@@ -60,32 +60,30 @@ export function getSiblingOperations(options: ParserOptions, gqlConfig: GraphQLC
 
   // We first try to use graphql-config for loading the operations paths, based on the type of the file,
   // We are using the directory of the file as the key for the schema caching, to avoid reloading of the schema.
-  if (options && options.filePath && !options.skipGraphQLConfig) {
+  if (gqlConfig && options?.filePath) {
     const fileDir = dirname(options.filePath);
 
     if (operationsCache.has(fileDir)) {
       siblings = operationsCache.get(fileDir);
     } else {
-      if (gqlConfig) {
-        const projectForFile = gqlConfig.getProjectForFile(options.filePath);
+      const projectForFile = gqlConfig.getProjectForFile(options.filePath);
 
-        if (projectForFile) {
-          siblings = projectForFile.getDocumentsSync();
-          operationsCache.set(fileDir, siblings);
-        }
+      if (projectForFile) {
+        siblings = projectForFile.getDocumentsSync();
+        operationsCache.set(fileDir, siblings);
       }
     }
   }
 
-  if (options && options.operations && !siblings) {
+  if (!siblings && options?.operations) {
     const loadPaths = Array.isArray(options.operations) ? options.operations : [options.operations] || [];
     const loadKey = loadPaths.join(',');
 
-    if (!operationsCache.has(loadKey)) {
+    if (operationsCache.has(loadKey)) {
+      siblings = operationsCache.get(loadKey);
+    } else {
       siblings = loadSiblings(process.cwd(), loadPaths);
       operationsCache.set(loadKey, siblings);
-    } else {
-      siblings = operationsCache.get(loadKey);
     }
   }
 


### PR DESCRIPTION
## Purpose

This PR aims to cache `graphql-config` object to avoid loading configuration for each linted file.

Related #233 

## Context

For now, we are loading the graphql configuration file in the parser, which is called by eslint for each linted file.

## Problem

Since the configuration should not change between the parsing of to files, we shouldn't reload it each time. It is a performance optimization but also a matters of coherence during execution. With a lot of files, there is a timming where we can change the configuration file during eslint parsing phase. Which will lead to have some file linted with old grpahql config, some other with the new one. 


## Solution

My proposition is to globally cache the graphql config object for the entire execution.

## What have been changed

I have moved out graphql-config logic to its own file which allow me to have a private mutable variable to store the cache of the configuration. Say me if you prefer to have this back in `parser.ts`.

I have also refactored some correlated code to make it more clear and remove redundant checks. Same thing, don't hesitate to make suggestions with your are not agree, I think those are more subjective changes.
