### PR TITLE
[naming-convention]  Add QueryDefinition option, forbiddenSuffixes and forbiddenPrefixes properties.

### DIFF
--- a/.changeset/funny-swans-speak.md
+++ b/.changeset/funny-swans-speak.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+[naming-convention] Add forbiddenPrefixes and forbiddenSuffixes options. Add QueryDefinition which targets queries ( may break existing config if FieldDefinition is used )

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -114,6 +114,13 @@ The object must be one of the following types:
 * `asString`
 * `asObject`
 
+#### `QueryDefinition`
+
+The object must be one of the following types:
+
+* `asString`
+* `asObject`
+
 #### `leadingUnderscore` (string, enum)
 
 This element must be one of the following enum values:

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -165,3 +165,19 @@ This element must be one of the following enum values:
 ### `prefix` (string)
 
 ### `suffix` (string)
+
+### `forbiddenPrefixes` (array)
+
+The object is an array with all elements of the type `string`.
+
+Additional restrictions:
+
+* Minimum items: `1`
+
+### `forbiddenSuffixes` (array)
+
+The object is an array with all elements of the type `string`.
+
+Additional restrictions:
+
+* Minimum items: `1`

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -343,7 +343,7 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       UnionTypeDefinition: node => {
         if (options.UnionTypeDefinition) {
           const property = normalisePropertyOption(options.UnionTypeDefinition);
-          checkNode(node.name, property, 'Scalar');
+          checkNode(node.name, property, 'Union');
         }
       },
     };

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -50,7 +50,8 @@ function checkNameFormat(params: CheckNameFormatParams): { ok: false; errorMessa
   if (forbiddenPrefixes.some(forbiddenPrefix => name.startsWith(forbiddenPrefix))) {
     return {
       ok: false,
-      errorMessage: '{{nodeType}} "{{nodeName}}" should not have one of the following prefixes: {{forbiddenPrefixes}}',
+      errorMessage:
+        '{{nodeType}} "{{nodeName}}" should not have one of the following prefix(es): {{forbiddenPrefixes}}',
     };
   }
 

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -305,7 +305,6 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
         }
       },
       FieldDefinition: (node: any) => {
-        // TODO: check proper node typing
         if (options.QueryDefinition && isQueryType(node.parent)) {
           const property = normalisePropertyOption(options.QueryDefinition);
           checkNode(node.name, property, 'Query');

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -208,5 +208,18 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         { message: 'Enumeration value name "VALUE_TWO" should have "ENUM" prefix' },
       ],
     },
+    {
+      code: 'type One { getC: String, queryD: String } type Query { getA(id: ID!): String, queryB: String }',
+      options: [
+        {
+          FieldDefinition: { style: 'camelCase', forbiddenPrefixes: ['foo', 'bar'] },
+          QueryDefinition: { style: 'camelCase', forbiddenPrefixes: ['get', 'query'] },
+        },
+      ],
+      errors: [
+        { message: 'Query "getA" should not have one of the following prefixes: get, query' },
+        { message: 'Query "queryB" should not have one of the following prefixes: get, query' },
+      ],
+    },
   ],
 });

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -212,13 +212,15 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       code: 'type One { getC: String, queryD: String } type Query { getA(id: ID!): String, queryB: String }',
       options: [
         {
+          ObjectTypeDefinition: { style: 'PascalCase', forbiddenPrefixes: ['On'] },
           FieldDefinition: { style: 'camelCase', forbiddenPrefixes: ['foo', 'bar'] },
           QueryDefinition: { style: 'camelCase', forbiddenPrefixes: ['get', 'query'] },
         },
       ],
       errors: [
-        { message: 'Query "getA" should not have one of the following prefixes: get, query' },
-        { message: 'Query "queryB" should not have one of the following prefixes: get, query' },
+        { message: 'Type "One" should not have one of the following prefix(es): On' },
+        { message: 'Query "getA" should not have one of the following prefix(es): get, query' },
+        { message: 'Query "queryB" should not have one of the following prefix(es): get, query' },
       ],
     },
   ],

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -209,7 +209,8 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       ],
     },
     {
-      code: 'type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String }',
+      code:
+        'type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }',
       options: [
         {
           ObjectTypeDefinition: { style: 'PascalCase', forbiddenPrefixes: ['On'] },
@@ -222,6 +223,7 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         { message: 'Field "getFoo" should not have one of the following suffix(es): Foo' },
         { message: 'Query "getA" should not have one of the following prefix(es): get, query' },
         { message: 'Query "queryB" should not have one of the following prefix(es): get, query' },
+        { message: 'Query "getC" should not have one of the following prefix(es): get, query' },
       ],
     },
   ],

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -103,6 +103,15 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: 'type One { fieldA: String } type Query { QUERY_A(id: ID!): String }',
+      options: [
+        {
+          FieldDefinition: { style: 'camelCase', prefix: 'field' },
+          QueryDefinition: { style: 'UPPER_CASE', prefix: 'QUERY' },
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -209,16 +209,17 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       ],
     },
     {
-      code: 'type One { getC: String, queryD: String } type Query { getA(id: ID!): String, queryB: String }',
+      code: 'type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String }',
       options: [
         {
           ObjectTypeDefinition: { style: 'PascalCase', forbiddenPrefixes: ['On'] },
-          FieldDefinition: { style: 'camelCase', forbiddenPrefixes: ['foo', 'bar'] },
+          FieldDefinition: { style: 'camelCase', forbiddenPrefixes: ['foo', 'bar'], forbiddenSuffixes: ['Foo'] },
           QueryDefinition: { style: 'camelCase', forbiddenPrefixes: ['get', 'query'] },
         },
       ],
       errors: [
         { message: 'Type "One" should not have one of the following prefix(es): On' },
+        { message: 'Field "getFoo" should not have one of the following suffix(es): Foo' },
         { message: 'Query "getA" should not have one of the following prefix(es): get, query' },
         { message: 'Query "queryB" should not have one of the following prefix(es): get, query' },
       ],


### PR DESCRIPTION
This PR implements the following:

- `QueryDefinition` option: This can be used specifically to target queries. As a result, the `FieldDefinition` option no longer targets queries which could be a breaking change
- `forbiddenPrefixes` property: used to report if any definition has one of the declared prefixes
- `forbiddenSuffixes` property: used to report if any definition has one of the declared suffixes

Other minor change(s):

- `checkNode` now takes full `property` object to make future properties easier to implement
- Fix wrong node type for UnionDefinition [here](https://github.com/dotansimha/graphql-eslint/pull/256/files#diff-9afe7600c3e6002f30eb08d02a06c30afda813baa781871f4b9c7af93039f2d6R345). Was `Scalar`, now `Union`

Related: https://github.com/dotansimha/graphql-eslint/issues/253