### PR TITLE
doc: fix readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## Available Rules
 
-- [`no-unreachable-types.md`](./no-unreachable-types.md)
+- [`no-unreachable-types`](./rules/no-unreachable-types.md)
 - [`no-deprecated`](./rules/no-deprecated.md)
 - [`unique-fragment-name`](./rules/unique-fragment-name.md)
 - [`unique-operation-name`](./rules/unique-operation-name.md)


### PR DESCRIPTION
@dotansimha sorry, missed the `rules` path in: https://github.com/dotansimha/graphql-eslint/pull/268. also removed the `md` extension in the link.

`unreachable types` works great now btw 🙌  but there seems to be a bug with (certain/or all) `interfaces` not being recognized as being used: https://github.com/dotansimha/graphql-eslint/issues/273

I'll try to create a repro and/or a PR.