### PR TITLE
Add options to input-name rule. Addresses #276

### DIFF
--- a/.changeset/early-turkeys-admire.md
+++ b/.changeset/early-turkeys-admire.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+Add options to input-name rule.

--- a/packages/plugin/tests/input-name.spec.ts
+++ b/packages/plugin/tests/input-name.spec.ts
@@ -10,6 +10,10 @@ ruleTester.runGraphQLTests('input-name', rule, {
       options: [{ checkInputType: true }],
     },
     {
+      code: 'type Mutation { SetMessage(input: SetMessageInput): String }',
+      options: [{ checkInputType: true }],
+    },
+    {
       code:
         'type Mutation { CreateMessage(input: CreateMessageInput): String DeleteMessage(input: DeleteMessageInput): Boolean }',
       options: [{ checkInputType: true }],
@@ -25,6 +29,31 @@ ruleTester.runGraphQLTests('input-name', rule, {
     'type Mutation { CreateMessage(input: String): String }',
     'extend type Mutation { CreateMessage(input: String): String }',
     'type Query { message(id: ID): Message }',
+    'extend type Query { message(id: ID): Message }',
+    {
+      code: 'type Mutation { userCreate(input: UserCreateInput): String }',
+      options: [{ checkInputType: true, caseSensitiveInputType: false }],
+    },
+    {
+      code: 'type Mutation { userCreate(input: userCreateInput): String }',
+      options: [{ checkInputType: true, caseSensitiveInputType: true }],
+    },
+    {
+      code: 'type Mutation { SetMessage(input: NonConforming): String }',
+      options: [{ checkMutations: false, checkInputType: true }],
+    },
+    {
+      code: 'type Mutation { SetMessage(input: String): String }',
+      options: [{ checkMutations: true, checkInputType: false }],
+    },
+    {
+      code: 'type Query { getMessage(input: NonConforming): String }',
+      options: [{ checkQueries: false, checkInputType: true }],
+    },
+    {
+      code: 'type Query { getMessage(input: String): String }',
+      options: [{ checkQueries: true, checkInputType: false }],
+    },
   ],
   invalid: [
     {
@@ -74,6 +103,21 @@ ruleTester.runGraphQLTests('input-name', rule, {
       code: 'type Mutation { userCreate(record: String, test: String): String }',
       options: [{ checkInputType: false }],
       errors: 2,
+    },
+    {
+      code: 'type Mutation { userCreate(input: String): String }',
+      options: [{ checkInputType: true, caseSensitiveInputType: false }],
+      errors: 1,
+    },
+    {
+      code: 'type Mutation { userCreate(input: UserCreateInput): String }',
+      options: [{ checkInputType: true, caseSensitiveInputType: true }],
+      errors: 1,
+    },
+    {
+      code: 'type Query { getUser(input: GetUserInput): String }',
+      options: [{ checkQueries: true, checkInputType: true, caseSensitiveInputType: true }],
+      errors: 1,
     },
   ],
 });


### PR DESCRIPTION
Add caseSensitiveInputType, checkMutations, checkQueries options to input-name rule

caseSensitiveInputType: When false the input type name must be <mutationName>Input but is not case sensitive.

checkMutations (default true): Apply this rule to mutations.

checkQueries (default false): Apply this rule to queries.

Setup default option values, previously all defaulting to undefined.

Also fixed documentation error which says that `checkInputType` defaults to `true`, when infact it defaults to `false`.

Addressed https://github.com/dotansimha/graphql-eslint/issues/276