### PR TITLE
[New rule] Add strict-id-in-types rule

### DIFF
--- a/.changeset/happy-trainers-doubt.md
+++ b/.changeset/happy-trainers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+[New rule] strict-id-in-types: use this to enforce output types to have a unique indentifier field unless being in exceptions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 ## Available Rules
 
+
 - [`no-unreachable-types`](./rules/no-unreachable-types.md)
 - [`no-deprecated`](./rules/no-deprecated.md)
 - [`unique-fragment-name`](./rules/unique-fragment-name.md)
@@ -18,6 +19,7 @@
 - [`avoid-duplicate-fields`](./rules/avoid-duplicate-fields.md)
 - [`naming-convention`](./rules/naming-convention.md)
 - [`input-name`](./rules/input-name.md)
+- [`strict-id-in-types`](./rules/strict-id-in-types.md)
 - [`prettier`](./rules/prettier.md)
 - [`executable-definitions`](./rules/executable-definitions.md)
 - [`fields-on-correct-type`](./rules/fields-on-correct-type.md)

--- a/docs/rules/executable-definitions.md
+++ b/docs/rules/executable-definitions.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid for execution if all definitions are either operation or fragment definitions.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ExecutableDefinitionsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ExecutableDefinitions.js).

--- a/docs/rules/fields-on-correct-type.md
+++ b/docs/rules/fields-on-correct-type.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all fields selected are defined by the parent type, or are an allowed meta field such as __typename.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FieldsOnCorrectTypeRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FieldsOnCorrectType.js).

--- a/docs/rules/fragments-on-composite-type.md
+++ b/docs/rules/fragments-on-composite-type.md
@@ -7,4 +7,4 @@
 
 Fragments use a type condition to determine if they apply, since fragments can only be spread into a composite type (object, interface, or union), the type condition must also be a composite type.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FragmentsOnCompositeTypesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FragmentsOnCompositeTypes.js).

--- a/docs/rules/input-name.md
+++ b/docs/rules/input-name.md
@@ -50,4 +50,24 @@ The array object has the following properties:
 
 #### `checkInputType` (boolean)
 
-Default: `"true"`
+Check that the input type name follows the convention <mutationName>Input
+
+Default: `false`
+
+#### `caseSensitiveInputType` (boolean)
+
+Allow for case discrepancies in the input type name
+
+Default: `true`
+
+#### `checkQueries` (boolean)
+
+Apply the rule to Queries
+
+Default: `false`
+
+#### `checkMutations` (boolean)
+
+Apply the rule to Mutations
+
+Default: `true`

--- a/docs/rules/known-argument-names.md
+++ b/docs/rules/known-argument-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL field is only valid if all supplied arguments are defined by that field.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownArgumentNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownArgumentNames.js).

--- a/docs/rules/known-directives.md
+++ b/docs/rules/known-directives.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all `@directives` are known by the schema and legally positioned.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownDirectivesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownDirectives.js).

--- a/docs/rules/known-fragment-names.md
+++ b/docs/rules/known-fragment-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownFragmentNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownFragmentNames.js).

--- a/docs/rules/known-type-names.md
+++ b/docs/rules/known-type-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownTypeNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/KnownTypeNames.js).

--- a/docs/rules/lone-anonymous-operation.md
+++ b/docs/rules/lone-anonymous-operation.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if when it contains an anonymous operation (the query short-hand) that it contains only that one operation definition.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/LoneAnonymousOperationRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/LoneAnonymousOperation.js).

--- a/docs/rules/lone-schema-definition.md
+++ b/docs/rules/lone-schema-definition.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if it contains only one schema definition.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/LoneSchemaDefinitionRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/LoneSchemaDefinition.js).

--- a/docs/rules/no-fragment-cycles.md
+++ b/docs/rules/no-fragment-cycles.md
@@ -7,4 +7,4 @@
 
 A GraphQL fragment is only valid when it does not have cycles in fragments usage.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoFragmentCyclesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoFragmentCycles.js).

--- a/docs/rules/no-undefined-variables.md
+++ b/docs/rules/no-undefined-variables.md
@@ -7,4 +7,4 @@
 
 A GraphQL operation is only valid if all variables encountered, both directly and via fragment spreads, are defined by that operation.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUndefinedVariablesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUndefinedVariables.js).

--- a/docs/rules/no-unreachable-types.md
+++ b/docs/rules/no-unreachable-types.md
@@ -3,39 +3,37 @@
 - Category: `Best Practices`
 - Rule name: `@graphql-eslint/no-unreachable-types`
 - Requires GraphQL Schema: `true` [ℹ️](../../README.md#extended-linting-rules-with-graphql-schema)
-- Requires GraphQL Operations: `false` [ℹ️](../../README.md#extended-linting-rules-with-siblings-operations)
 
-This rule allow you to enforce that all types have to reachable by root level fields (Query.*, Mutation.*, Subscription.*).
+Requires all types to be reachable at some level by root level fields
 
 ## Usage Examples
 
-### Incorrect (field)
+### Incorrect
 
 ```graphql
 # eslint @graphql-eslint/no-unreachable-types: ["error"]
 
+type User {
+  id: ID!
+  name: String
+}
+
 type Query {
   me: String
 }
-
-type User { # This is not used, so you'll get an error
-  id: ID!
-  name: String!
-}
 ```
-
 
 ### Correct
 
 ```graphql
 # eslint @graphql-eslint/no-unreachable-types: ["error"]
 
-type Query {
-  me: User
+type User {
+  id: ID!
+  name: String
 }
 
-type User { # This is now used, so you won't get an error
-  id: ID!
-  name: String!
+type Query {
+  me: User
 }
 ```

--- a/docs/rules/no-unused-fragments.md
+++ b/docs/rules/no-unused-fragments.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all fragment definitions are spread within operations, or spread within other fragments spread within operations.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUnusedFragmentsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUnusedFragments.js).

--- a/docs/rules/no-unused-variables.md
+++ b/docs/rules/no-unused-variables.md
@@ -7,4 +7,4 @@
 
 A GraphQL operation is only valid if all variables defined by an operation are used, either directly or within a spread fragment.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUnusedVariablesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/NoUnusedVariables.js).

--- a/docs/rules/one-field-subscriptions.md
+++ b/docs/rules/one-field-subscriptions.md
@@ -7,4 +7,4 @@
 
 A GraphQL subscription is valid only if it contains a single root field.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/SingleFieldSubscriptionsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/SingleFieldSubscriptions.js).

--- a/docs/rules/overlapping-fields-can-be-merged.md
+++ b/docs/rules/overlapping-fields-can-be-merged.md
@@ -7,4 +7,4 @@
 
 A selection set is only valid if all fields (including spreading any fragments) either correspond to distinct response names or can be merged without ambiguity.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/OverlappingFieldsCanBeMergedRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/OverlappingFieldsCanBeMerged.js).

--- a/docs/rules/possible-fragment-spread.md
+++ b/docs/rules/possible-fragment-spread.md
@@ -7,4 +7,4 @@
 
 A fragment spread is only valid if the type condition could ever possibly be true: if there is a non-empty intersection of the possible parent types, and possible types which pass the type condition.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/PossibleFragmentSpreadsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/PossibleFragmentSpreads.js).

--- a/docs/rules/possible-type-extension.md
+++ b/docs/rules/possible-type-extension.md
@@ -7,4 +7,4 @@
 
 A type extension is only valid if the type is defined and has the same kind.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/PossibleTypeExtensionsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/PossibleTypeExtensions.js).

--- a/docs/rules/provided-required-arguments.md
+++ b/docs/rules/provided-required-arguments.md
@@ -7,4 +7,4 @@
 
 A field or directive is only valid if all required (non-null without a default value) field arguments have been provided.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ProvidedRequiredArgumentsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ProvidedRequiredArguments.js).

--- a/docs/rules/scalar-leafs.md
+++ b/docs/rules/scalar-leafs.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is valid only if all leaf fields (fields without sub selections) are of scalar or enum types.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ScalarLeafsRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ScalarLeafs.js).

--- a/docs/rules/selection-set-depth.md
+++ b/docs/rules/selection-set-depth.md
@@ -53,4 +53,18 @@ query deep2 {
 
 ## Config Schema
 
-The schema defines the following properties:
+### (array)
+
+The schema defines an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+#### `maxDepth` (number)
+
+#### `ignore` (array)
+
+The object is an array with all elements of the type `string`.
+
+Additional restrictions:
+
+* Minimum items: `1`

--- a/docs/rules/strict-id-in-types.md
+++ b/docs/rules/strict-id-in-types.md
@@ -53,3 +53,49 @@ type CreateUserPayload {
   data: String!
 }
 ```
+
+## Config Schema
+
+### (array)
+
+The schema defines an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+#### `acceptedIdNames` (array)
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[
+  "id"
+]
+```
+
+#### `acceptedIdTypes` (array)
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[
+  "ID"
+]
+```
+
+#### `exceptions` (object)
+
+Properties of the `exceptions` object:
+
+##### `suffixes` (array)
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```

--- a/docs/rules/strict-id-in-types.md
+++ b/docs/rules/strict-id-in-types.md
@@ -1,4 +1,55 @@
 # `strict-id-in-types`
 
+- Category: `Best practices`
 - Rule name: `@graphql-eslint/strict-id-in-types`
+- Requires GraphQL Schema: `false` [ℹ️](../../README.md#extended-linting-rules-with-graphql-schema)
+- Requires GraphQL Operations: `false` [ℹ️](../../README.md#extended-linting-rules-with-siblings-operations)
 
+Requires output types to have one unique identifier unless they do not have a logical one. Exceptions can be used to ignore output types that do not have unique identifiers.
+
+## Usage Examples
+
+### Incorrect
+
+```graphql
+# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"suffixes":["Payload"]}}]]
+
+# Incorrect field name
+type InvalidFieldName {
+  key: ID!
+}
+
+# Incorrect field type
+type InvalidFieldType {
+  id: String!
+}
+
+# Incorrect exception suffix
+type InvalidSuffixResult {
+  data: String!
+}
+
+# Too many unique identifiers. Must only contain one.
+type InvalidFieldName {
+  id: ID!
+  _id: ID!
+}
+```
+
+### Correct
+
+```graphql
+# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"suffixes":["Payload"]}}]]
+
+type User {
+  id: ID!
+}
+
+type Post {
+  _id: ID!
+}
+
+type CreateUserPayload {
+  data: String!
+}
+```

--- a/docs/rules/strict-id-in-types.md
+++ b/docs/rules/strict-id-in-types.md
@@ -39,7 +39,7 @@ type InvalidFieldName {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"suffixes":["Payload"]}}]]
+# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"types":["Error"],"suffixes":["Payload"]}}]]
 
 type User {
   id: ID!
@@ -51,6 +51,10 @@ type Post {
 
 type CreateUserPayload {
   data: String!
+}
+
+type Error {
+  message: String!
 }
 ```
 
@@ -90,7 +94,21 @@ Default:
 
 Properties of the `exceptions` object:
 
+##### `types` (array)
+
+This is used to exclude types with names that match one of the specified values.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
 ##### `suffixes` (array)
+
+This is used to exclude types with names with suffixes that match one of the specified values.
 
 The object is an array with all elements of the type `string`.
 

--- a/docs/rules/strict-id-in-types.md
+++ b/docs/rules/strict-id-in-types.md
@@ -1,0 +1,4 @@
+# `strict-id-in-types`
+
+- Rule name: `@graphql-eslint/strict-id-in-types`
+

--- a/docs/rules/unique-argument-names.md
+++ b/docs/rules/unique-argument-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL field or directive is only valid if all supplied arguments are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueArgumentNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueArgumentNames.js).

--- a/docs/rules/unique-directive-names-per-location.md
+++ b/docs/rules/unique-directive-names-per-location.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all non-repeatable directives at a given location are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueDirectivesPerLocationRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueDirectivesPerLocation.js).

--- a/docs/rules/unique-directive-names.md
+++ b/docs/rules/unique-directive-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all defined directives have unique names.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueDirectiveNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueDirectiveNames.js).

--- a/docs/rules/unique-enum-value-names.md
+++ b/docs/rules/unique-enum-value-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL enum type is only valid if all its values are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueEnumValueNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueEnumValueNames.js).

--- a/docs/rules/unique-field-definition-names.md
+++ b/docs/rules/unique-field-definition-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL complex type is only valid if all its fields are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueFieldDefinitionNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueFieldDefinitionNames.js).

--- a/docs/rules/unique-input-field-names.md
+++ b/docs/rules/unique-input-field-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL input object value is only valid if all supplied fields are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueInputFieldNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueInputFieldNames.js).

--- a/docs/rules/unique-operation-types.md
+++ b/docs/rules/unique-operation-types.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if it has only one type per operation.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueOperationTypesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueOperationTypes.js).

--- a/docs/rules/unique-type-names.md
+++ b/docs/rules/unique-type-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all defined types have unique names.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueTypeNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueTypeNames.js).

--- a/docs/rules/unique-variable-names.md
+++ b/docs/rules/unique-variable-names.md
@@ -7,4 +7,4 @@
 
 A GraphQL operation is only valid if all its variables are uniquely named.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueVariableNamesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueVariableNames.js).

--- a/docs/rules/value-literals-of-correct-type.md
+++ b/docs/rules/value-literals-of-correct-type.md
@@ -7,4 +7,4 @@
 
 A GraphQL document is only valid if all value literals are of the type expected at their position.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ValuesOfCorrectTypeRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ValuesOfCorrectType.js).

--- a/docs/rules/variables-are-input-types.md
+++ b/docs/rules/variables-are-input-types.md
@@ -7,4 +7,4 @@
 
 A GraphQL operation is only valid if all the variables it defines are of input types (scalar, enum, or input object).
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/VariablesAreInputTypesRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/VariablesAreInputTypes.js).

--- a/docs/rules/variables-in-allowed-position.md
+++ b/docs/rules/variables-in-allowed-position.md
@@ -7,4 +7,4 @@
 
 Variables passed to field arguments conform to type.
 
-> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/VariablesInAllowedPositionRule.js).
+> This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/VariablesInAllowedPosition.js).

--- a/packages/plugin/src/rules/index.ts
+++ b/packages/plugin/src/rules/index.ts
@@ -17,6 +17,7 @@ import noDeprecated from './no-deprecated';
 import noHashtagDescription from './no-hashtag-description';
 import selectionSetDepth from './selection-set-depth';
 import avoidDuplicateFields from './avoid-duplicate-fields';
+import strictIdInTypes from './strict-id-in-types';
 import { GraphQLESLintRule } from '../types';
 import { GRAPHQL_JS_VALIDATIONS } from './graphql-js-validation';
 
@@ -39,6 +40,7 @@ export const rules: Record<string, GraphQLESLintRule> = {
   'avoid-duplicate-fields': avoidDuplicateFields,
   'naming-convention': namingConvention,
   'input-name': inputName,
+  'strict-id-in-types': strictIdInTypes,
   prettier,
   ...GRAPHQL_JS_VALIDATIONS,
 };

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -30,8 +30,60 @@ const shouldIgnoreNode = ({ node, exceptions }: ShouldIgnoreNodeParams): boolean
 
 const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
   meta: {
+    type: 'suggestion',
     docs: {
+      description:
+        'Requires output types to have one unique identifier unless they do not have a logical one. Exceptions can be used to ignore output types that do not have unique identifiers.',
+      category: 'Best practices',
+      recommended: true,
+      requiresSchema: false,
+      requiresSiblings: false,
       url: 'https://github.com/dotansimha/graphql-eslint/blob/master/docs/rules/strict-id-in-types.md',
+      examples: [
+        {
+          title: 'Incorrect',
+          usage: [{ acceptedIdNames: ['id', '_id'], acceptedIdTypes: ['ID'], exceptions: { suffixes: ['Payload'] } }],
+          code: /* GraphQL */ `
+            # Incorrect field name
+            type InvalidFieldName {
+              key: ID!
+            }
+
+            # Incorrect field type
+            type InvalidFieldType {
+              id: String!
+            }
+
+            # Incorrect exception suffix
+            type InvalidSuffixResult {
+              data: String!
+            }
+
+            # Too many unique identifiers. Must only contain one.
+            type InvalidFieldName {
+              id: ID!
+              _id: ID!
+            }
+          `,
+        },
+        {
+          title: 'Correct',
+          usage: [{ acceptedIdNames: ['id', '_id'], acceptedIdTypes: ['ID'], exceptions: { suffixes: ['Payload'] } }],
+          code: /* GraphQL */ `
+            type User {
+              id: ID!
+            }
+
+            type Post {
+              _id: ID!
+            }
+
+            type CreateUserPayload {
+              data: String!
+            }
+          `,
+        },
+      ],
     },
   },
   create(context) {

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -85,6 +85,41 @@ const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
         },
       ],
     },
+    schema: {
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          acceptedIdNames: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            default: ['id'],
+          },
+          acceptedIdTypes: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            default: ['ID'],
+          },
+          exceptions: {
+            type: 'object',
+            properties: {
+              suffixes: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                default: [],
+              },
+            },
+          },
+        },
+      },
+    },
   },
   create(context) {
     const options: StrictIdInTypesRuleConfig[number] = {

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -29,6 +29,11 @@ const shouldIgnoreNode = ({ node, exceptions }: ShouldIgnoreNodeParams): boolean
 };
 
 const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
+  meta: {
+    docs: {
+      url: 'https://github.com/dotansimha/graphql-eslint/blob/master/docs/rules/strict-id-in-types.md',
+    },
+  },
   create(context) {
     const options: StrictIdInTypesRuleConfig[number] = {
       acceptedIdNames: ['id'],

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -1,0 +1,21 @@
+import { GraphQLESLintRule } from '../types';
+
+type StrictIdInTypesRuleConfig = [
+  {
+    acceptedIdNames?: string[];
+    acceptedIdTypes?: string[];
+    exceptions?: {
+      suffixes?: string[];
+    };
+  }
+];
+
+const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
+  create(context) {
+    return {
+      FieldDefinition(node) {},
+    };
+  },
+};
+
+export default rule;

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -149,6 +149,9 @@ const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
           return isValidIdName && isValidIdType;
         });
 
+        // Usually, there should be only one unique identifier field per type.
+        // Some clients allow multiple fields to be used. If more people need this,
+        // we can extend this rule later.
         if (validIds.length !== 1) {
           context.report({
             node,

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -12,8 +12,41 @@ type StrictIdInTypesRuleConfig = [
 
 const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
   create(context) {
+    const options: StrictIdInTypesRuleConfig[number] = {
+      acceptedIdNames: ['id'],
+      acceptedIdTypes: ['ID'],
+      ...(context.options[0] || {}),
+    };
+
     return {
-      FieldDefinition(node) {},
+      ObjectTypeDefinition(node) {
+        const validIds = node.fields.filter(field => {
+          const fieldNode = field.rawNode();
+
+          const isValidIdName = options.acceptedIdNames.includes(fieldNode.name.value);
+
+          // To be a valid type, it must be non-null and one of the accepted types.
+          let isValidIdType = false;
+          if (fieldNode.type.kind === 'NonNullType' && fieldNode.type.type.kind === 'NamedType') {
+            isValidIdType = options.acceptedIdTypes.includes(fieldNode.type.type.name.value);
+          }
+
+          return isValidIdName && isValidIdType;
+        });
+
+        if (validIds.length !== 1) {
+          context.report({
+            node,
+            message:
+              '{{nodeName}} must have exactly one non-nullable unique identifier. Accepted name(s): {{acceptedNamesString}} ; Accepted type(s): {{acceptedTypesString}}',
+            data: {
+              nodeName: node.name.value,
+              acceptedNamesString: options.acceptedIdNames.join(','),
+              acceptedTypesString: options.acceptedIdTypes.join(','),
+            },
+          });
+        }
+      },
     };
   },
 };

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinitionNode } from 'graphql';
+import { Kind, ObjectTypeDefinitionNode } from 'graphql';
 import { GraphQLESTreeNode } from '../estree-parser';
 import { GraphQLESLintRule } from '../types';
 
@@ -142,7 +142,7 @@ const rule: GraphQLESLintRule<StrictIdInTypesRuleConfig> = {
 
           // To be a valid type, it must be non-null and one of the accepted types.
           let isValidIdType = false;
-          if (fieldNode.type.kind === 'NonNullType' && fieldNode.type.type.kind === 'NamedType') {
+          if (fieldNode.type.kind === Kind.NON_NULL_TYPE && fieldNode.type.type.kind === Kind.NAMED_TYPE) {
             isValidIdType = options.acceptedIdTypes.includes(fieldNode.type.type.name.value);
           }
 

--- a/packages/plugin/tests/strict-id-in-types.spec.ts
+++ b/packages/plugin/tests/strict-id-in-types.spec.ts
@@ -75,6 +75,55 @@ ruleTester.runGraphQLTests('strict-id-in-types', rule, {
         },
       ],
     },
+    {
+      code: 'type A { id: ID! } type AError { message: String! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            types: ['AError'],
+          },
+        },
+      ],
+    },
+    {
+      code: 'type A { id: ID! } type AGeneralError { message: String! } type AForbiddenError { message: String! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            types: ['AGeneralError', 'AForbiddenError'],
+          },
+        },
+      ],
+    },
+    {
+      code: 'type A { id: ID! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            types: [''],
+          },
+        },
+      ],
+    },
+    {
+      code: 'type A { id: ID! } type AError { message: String! } type AResult { payload: A! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            types: ['AError'],
+            suffixes: ['Result'],
+          },
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -149,6 +198,24 @@ ruleTester.runGraphQLTests('strict-id-in-types', rule, {
         {
           message:
             'BPagination must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): ID',
+        },
+      ],
+    },
+    {
+      code: 'type B { id: ID! } type BError { message: String! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            types: ['GeneralError'],
+          },
+        },
+      ],
+      errors: [
+        {
+          message:
+            'BError must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): ID',
         },
       ],
     },

--- a/packages/plugin/tests/strict-id-in-types.spec.ts
+++ b/packages/plugin/tests/strict-id-in-types.spec.ts
@@ -1,0 +1,84 @@
+import { GraphQLRuleTester } from '../src/testkit';
+import rule from '../src/rules/strict-id-in-types';
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests('strict-id-in-types', rule, {
+  valid: [
+    {
+      code: 'type A { id: ID! }',
+    },
+    {
+      code: 'type A { _id: String! }',
+      options: [
+        {
+          acceptedIdNames: ['_id'],
+          acceptedIdTypes: ['String'],
+        },
+      ],
+    },
+    {
+      code: 'type A { _id: String! } type A1 { id: ID! }',
+      options: [
+        {
+          acceptedIdNames: ['id', '_id'],
+          acceptedIdTypes: ['ID', 'String'],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: 'type B { name: String! }',
+      errors: [
+        {
+          message:
+            'B must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): ID',
+        },
+      ],
+    },
+    {
+      code: 'type B { id: ID! _id: String! }',
+      options: [
+        {
+          acceptedIdNames: ['id', '_id'],
+          acceptedIdTypes: ['ID', 'String'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'B must have exactly one non-nullable unique identifier. Accepted name(s): id,_id ; Accepted type(s): ID,String',
+        },
+      ],
+    },
+    {
+      code:
+        'type B { id: String! } type B1 { id: [String] } type B2 { id: [String!] } type B3 { id: [String]! } type B4 { id: [String!]! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['String'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'B1 must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): String',
+        },
+        {
+          message:
+            'B2 must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): String',
+        },
+        {
+          message:
+            'B3 must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): String',
+        },
+        {
+          message:
+            'B4 must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): String',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/plugin/tests/strict-id-in-types.spec.ts
+++ b/packages/plugin/tests/strict-id-in-types.spec.ts
@@ -26,6 +26,55 @@ ruleTester.runGraphQLTests('strict-id-in-types', rule, {
         },
       ],
     },
+    {
+      code: 'type A { id: ID! } type AResult { key: String! } ',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            suffixes: ['Result'],
+          },
+        },
+      ],
+    },
+    {
+      code: 'type A { id: ID! } type A1 { id: ID! } ',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            suffixes: [''],
+          },
+        },
+      ],
+    },
+    {
+      code: 'type A { id: ID! } type A1 { id: ID! } ',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            suffixes: [],
+          },
+        },
+      ],
+    },
+    {
+      code:
+        'type A { id: ID! } type AResult { key: String! } type APayload { bool: Boolean! } type APagination { num: Int! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            suffixes: ['Result', 'Payload', 'Pagination'],
+          },
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -77,6 +126,29 @@ ruleTester.runGraphQLTests('strict-id-in-types', rule, {
         {
           message:
             'B4 must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): String',
+        },
+      ],
+    },
+    {
+      code:
+        'type B { id: ID! } type Bresult { key: String! } type BPayload { bool: Boolean! } type BPagination { num: Int! }',
+      options: [
+        {
+          acceptedIdNames: ['id'],
+          acceptedIdTypes: ['ID'],
+          exceptions: {
+            suffixes: ['Result', 'Payload'],
+          },
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Bresult must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): ID',
+        },
+        {
+          message:
+            'BPagination must have exactly one non-nullable unique identifier. Accepted name(s): id ; Accepted type(s): ID',
         },
       ],
     },


### PR DESCRIPTION
## Description

This PR adds a new rule `strict-id-in-types`. 

Usually, a GraphQL output type can be mapped to a domain model e.g. `User`, `Post`, `Comment`. These fields should have a logical database `id` which could be used as the unique identifier of the correspondent GraphQL output type. There are some exceptions: Payload/Result, Pagination, or types used to group related fields together.

This rule enforces all output types to have a unique identifier field unless belonging to the exceptions. This ensures the consistency of output types in the schema.

The default name is `id` and the default type is `ID`. A lot of GraphQL clients e.g. Apollo client and urql uses the `id` field of incoming data to normalise the cache so consistency from the schema level will help writing documents as well.

### Options

- `acceptedIdNames`: an array of strings containing field names that could be used as unique identifier. Works in tandem with `acceptedIdTypes`. Default: `["id"]`
- `acceptedIdTypes`: an array of strings containing field types that could be used as unique identifier. Works in tandem with `acceptedIdNames`. Default: `["ID"]`
- `exceptions`: an object containing properties of a type to be ignored.
  - `suffixes`: Any type that has one of the options declared here should be ignored. Default: `[]`

Related https://github.com/dotansimha/graphql-eslint/issues/326

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

I have added the tests in this file: https://github.com/eddeee888/graphql-eslint/blob/2f7efe34967cf26711897bcc614461eb3aa788c0/packages/plugin/tests/strict-id-in-types.spec.ts
To test, run `yarn test strict-id-in-types`

**Test Environment**:
- OS: MacOS
- `@graphql-eslint/...`: Latest versions
- NodeJS: 12.13.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

- When running `yarn generate:docs`, it changed a lot of unrelated doc files. This makes me think that the latest version on `master` may not have run generate:docs? 🤔  Please let me know how we should deal with this issue.
- It would be good to try this on an alpha version for some of my projects before releasing. Please let me know if it's possible :)
