### PR TITLE
fix: original file should not be considered as file block

### DIFF
--- a/.changeset/empty-donuts-destroy.md
+++ b/.changeset/empty-donuts-destroy.md
@@ -1,0 +1,11 @@
+---
+"@graphql-eslint/eslint-plugin": patch
+---
+
+fix: original file should not be considered as file block
+
+Related #88
+
+ESLint supports `text` directly, no need to use the hacky way. See https://github.com/eslint/eslint/blob/master/lib/linter/linter.js#L1298
+
+Related `eslint-plugin-prettier`'s issue hae been fixed at https://github.com/prettier/eslint-plugin-prettier/pull/401


### PR DESCRIPTION
Related #88

ESLint supports `text` directly, no need to use the hacky way. See https://github.com/eslint/eslint/blob/master/lib/linter/linter.js#L1298

Besides, I've fixed related `eslint-plugin-prettier`'s issue at https://github.com/prettier/eslint-plugin-prettier/pull/401