### PR TITLE
Fix generated documentation for certain rules

### DIFF
--- a/docs/rules/avoid-operation-name-prefix.md
+++ b/docs/rules/avoid-operation-name-prefix.md
@@ -12,7 +12,7 @@ Enforce/avoid operation name prefix, useful if you wish to avoid prefix in your 
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/avoid-operation-name-prefix: ["error", [{"keywords":["get"]}]]
+# eslint @graphql-eslint/avoid-operation-name-prefix: ["error", {"keywords":["get"]}]
 
 query getUserDetails {
   # ...
@@ -22,7 +22,7 @@ query getUserDetails {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/avoid-operation-name-prefix: ["error", [{"keywords":["get"]}]]
+# eslint @graphql-eslint/avoid-operation-name-prefix: ["error", {"keywords":["get"]}]
 
 query userDetails {
   # ...

--- a/docs/rules/description-style.md
+++ b/docs/rules/description-style.md
@@ -12,7 +12,7 @@ Require all comments to follow the same style (either block or inline)
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/description-style: ["error", [{"style":"inline"}]]
+# eslint @graphql-eslint/description-style: ["error", {"style":"inline"}]
 
 """ Description """
 type someTypeName {
@@ -23,7 +23,7 @@ type someTypeName {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/description-style: ["error", [{"style":"inline"}]]
+# eslint @graphql-eslint/description-style: ["error", {"style":"inline"}]
 
 " Description "
 type someTypeName {

--- a/docs/rules/input-name.md
+++ b/docs/rules/input-name.md
@@ -13,7 +13,7 @@ Using the same name for all input parameters will make your schemas easier to co
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/input-name: ["error", [{"checkInputType":true}]]
+# eslint @graphql-eslint/input-name: ["error", {"checkInputType":true}]
 
 type Mutation {
   SetMessage(message: InputMessage): String
@@ -23,7 +23,7 @@ type Mutation {
 ### Correct (with checkInputType)
 
 ```graphql
-# eslint @graphql-eslint/input-name: ["error", [{"checkInputType":true}]]
+# eslint @graphql-eslint/input-name: ["error", {"checkInputType":true}]
 
 type Mutation {
   SetMessage(input: SetMessageInput): String
@@ -33,7 +33,7 @@ type Mutation {
 ### Correct (without checkInputType)
 
 ```graphql
-# eslint @graphql-eslint/input-name: ["error", [{"checkInputType":false}]]
+# eslint @graphql-eslint/input-name: ["error", {"checkInputType":false}]
 
 type Mutation {
   SetMessage(input: AnyInputTypeName): String

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -12,7 +12,7 @@ Require names to follow specified conventions.
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/naming-convention: ["error", [{"ObjectTypeDefinition":"PascalCase"}]]
+# eslint @graphql-eslint/naming-convention: ["error", {"ObjectTypeDefinition":"PascalCase"}]
 
 type someTypeName {
   f: String!
@@ -22,7 +22,7 @@ type someTypeName {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/naming-convention: ["error", [{"FieldDefinition":"camelCase","ObjectTypeDefinition":"PascalCase"}]]
+# eslint @graphql-eslint/naming-convention: ["error", {"FieldDefinition":"camelCase","ObjectTypeDefinition":"PascalCase"}]
 
 type SomeTypeName {
   someFieldName: String

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -12,7 +12,7 @@ Enforce descriptions in your type definitions
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/require-description: ["error", [{"on":["ObjectTypeDefinition","FieldDefinition"]}]]
+# eslint @graphql-eslint/require-description: ["error", {"on":["ObjectTypeDefinition","FieldDefinition"]}]
 
 type someTypeName {
   name: String
@@ -22,7 +22,7 @@ type someTypeName {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/require-description: ["error", [{"on":["ObjectTypeDefinition","FieldDefinition"]}]]
+# eslint @graphql-eslint/require-description: ["error", {"on":["ObjectTypeDefinition","FieldDefinition"]}]
 
 """
 Some type description

--- a/docs/rules/selection-set-depth.md
+++ b/docs/rules/selection-set-depth.md
@@ -12,7 +12,7 @@ Limit the complexity of the GraphQL operations solely by their depth. Based on h
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/selection-set-depth: ["error", [{"maxDepth":1}]]
+# eslint @graphql-eslint/selection-set-depth: ["error", {"maxDepth":1}]
 
 query deep2 {
   viewer { # Level 0
@@ -26,7 +26,7 @@ query deep2 {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/selection-set-depth: ["error", [{"maxDepth":4}]]
+# eslint @graphql-eslint/selection-set-depth: ["error", {"maxDepth":4}]
 
 query deep2 {
   viewer { # Level 0
@@ -40,7 +40,7 @@ query deep2 {
 ### Correct (ignored field)
 
 ```graphql
-# eslint @graphql-eslint/selection-set-depth: ["error", [{"maxDepth":1,"ignore":["albums"]}]]
+# eslint @graphql-eslint/selection-set-depth: ["error", {"maxDepth":1,"ignore":["albums"]}]
 
 query deep2 {
   viewer { # Level 0

--- a/docs/rules/strict-id-in-types.md
+++ b/docs/rules/strict-id-in-types.md
@@ -12,7 +12,7 @@ Requires output types to have one unique identifier unless they do not have a lo
 ### Incorrect
 
 ```graphql
-# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"suffixes":["Payload"]}}]]
+# eslint @graphql-eslint/strict-id-in-types: ["error", {"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"suffixes":["Payload"]}}]
 
 # Incorrect field name
 type InvalidFieldName {
@@ -39,7 +39,7 @@ type InvalidFieldName {
 ### Correct
 
 ```graphql
-# eslint @graphql-eslint/strict-id-in-types: ["error", [{"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"types":["Error"],"suffixes":["Payload"]}}]]
+# eslint @graphql-eslint/strict-id-in-types: ["error", {"acceptedIdNames":["id","_id"],"acceptedIdTypes":["ID"],"exceptions":{"types":["Error"],"suffixes":["Payload"]}}]
 
 type User {
   id: ID!

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -48,10 +48,11 @@ async function main() {
       blocks.push(BR, `## Usage Examples`);
 
       for (const example of examples) {
+        // ESLint RuleTester accept options as array but in eslintrc config we must provide options as object
+        const options = example.usage ? ', ' + JSON.stringify(example.usage[0]) : '';
+
         blocks.push(
-          `\n### ${example.title}\n\n\`\`\`graphql\n# eslint @graphql-eslint/${ruleName}: ["error"${
-            example.usage ? ', ' + JSON.stringify(example.usage) : ''
-          }]\n\n${dedent(example.code)}\n\`\`\``
+          `\n### ${example.title}\n\n\`\`\`graphql\n# eslint @graphql-eslint/${ruleName}: ["error"${options}]\n\n${dedent(example.code)}\n\`\`\``,
         );
       }
     }


### PR DESCRIPTION
Issue: https://github.com/dotansimha/graphql-eslint/issues/410

The mistake is that ESLint RuleTester accept options as array https://github.com/eslint/eslint/blob/master/lib/rule-tester/rule-tester.js#L497 but in eslintrc config we must provide options as object

after review you can close this pr #329 as i fixed generated docs code ;)