### PR TITLE
Support OperationDefinition naming convention

### DIFF
--- a/.changeset/ninety-colts-switch.md
+++ b/.changeset/ninety-colts-switch.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Support OperationDefinition in naming-convention rule

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+    exit $exitCode
+  fi
+
+  exit 0
+fi

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -327,6 +327,12 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
           checkNode(node.name, property, 'Input property');
         }
       },
+      OperationDefinition: node => {
+        if (options.OperationDefinition) {
+          const property = normalisePropertyOption(options.OperationDefinition);
+          checkNode(node.name, property, 'Operation');
+        }
+      },
       FragmentDefinition: node => {
         if (options.FragmentDefinition) {
           const property = normalisePropertyOption(options.FragmentDefinition);

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -24,6 +24,7 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
       }`,
       options: [
         {
+          OperationDefinition: 'PascalCase',
           ObjectTypeDefinition: 'PascalCase',
           FieldDefinition: 'camelCase',
           EnumValueDefinition: 'UPPER_CASE',
@@ -224,6 +225,18 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         { message: 'Query "getA" should not have one of the following prefix(es): get, query' },
         { message: 'Query "queryB" should not have one of the following prefix(es): get, query' },
         { message: 'Query "getC" should not have one of the following prefix(es): get, query' },
+      ],
+    },
+    {
+      code: 'query Foo { foo } query getBar { bar }',
+      options: [
+        {
+          OperationDefinition: { style: 'camelCase', forbiddenPrefixes: ['get'] },
+        },
+      ],
+      errors: [
+        { message: 'Operation name "Foo" should be in camelCase format' },
+        { message: 'Operation "getBar" should not have one of the following prefix(es): get' },
       ],
     },
   ],


### PR DESCRIPTION
## Description
- Make naming-convention rule able to handle OperationDefinition.
  - This feature was already in the [document](https://github.com/dotansimha/graphql-eslint/blob/master/docs/rules/naming-convention.md#operationdefinition), but it doesn't work.
- Also, I added a simple test for this change.



Fixes #380 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
