### PR TITLE
fix: allow anonymous operations for `naming-convention` rule

### DIFF
--- a/.changeset/fuzzy-dolphins-attack.md
+++ b/.changeset/fuzzy-dolphins-attack.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: allow anonymous operations for naming-convention rule

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -330,7 +330,9 @@ const rule: GraphQLESLintRule<NamingConventionRuleConfig> = {
       OperationDefinition: node => {
         if (options.OperationDefinition) {
           const property = normalisePropertyOption(options.OperationDefinition);
-          checkNode(node.name, property, 'Operation');
+          if (node.name) {
+            checkNode(node.name, property, 'Operation');
+          }
         }
       },
       FragmentDefinition: node => {

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -113,6 +113,10 @@ ruleTester.runGraphQLTests('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: 'query { foo }',
+      options: [{ OperationDefinition: { style: 'PascalCase' } }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-eslint/issues/435

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
