### PR TITLE
Fix console.warn typo in `selection-set-depth` rule

### DIFF
--- a/.changeset/stupid-glasses-kneel.md
+++ b/.changeset/stupid-glasses-kneel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Fix console.warn typo in selection-set-depth rule

--- a/packages/plugin/src/rules/selection-set-depth.ts
+++ b/packages/plugin/src/rules/selection-set-depth.ts
@@ -88,7 +88,7 @@ const rule: GraphQLESLintRule<SelectionSetDepthRuleConfig> = {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Rule "selection-set-depth" works best with sibligns operations loaded. For more info: http://bit.ly/graphql-eslint-operations`
+        `Rule "selection-set-depth" works best with siblings operations loaded. For more info: http://bit.ly/graphql-eslint-operations`
       );
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
