### PR TITLE
🎉 New feature: Support `#import` for `known-fragment-names` rule

### DIFF
--- a/.changeset/dry-vans-smile.md
+++ b/.changeset/dry-vans-smile.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+support #import in known-fragment-names rule

--- a/docs/rules/known-fragment-names.md
+++ b/docs/rules/known-fragment-names.md
@@ -8,3 +8,51 @@
 A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document.
 
 > This rule is a wrapper around a `graphql-js` validation function. [You can find it's source code here](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/KnownFragmentNamesRule.ts).
+
+## Usage Examples
+
+### Incorrect (fragment not defined in the document)
+
+```graphql
+# eslint @graphql-eslint/known-fragment-names: ["error"]
+
+query {
+  user {
+    id
+    ...UserFields
+  }
+}
+```
+
+### Correct
+
+```graphql
+# eslint @graphql-eslint/known-fragment-names: ["error"]
+
+fragment UserFields on User {
+  firstName
+  lastName
+}
+
+query {
+  user {
+    id
+    ...UserFields
+  }
+}
+```
+
+### Correct (existing import to UserFields fragment)
+
+```graphql
+# eslint @graphql-eslint/known-fragment-names: ["error"]
+
+#import '../UserFields.gql'
+
+query {
+  user {
+    id
+    ...UserFields
+  }
+}
+```

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -128,6 +128,48 @@ export const GRAPHQL_JS_VALIDATIONS = Object.assign(
   validationToRule('known-fragment-names', 'KnownFragmentNames', {
     docs: {
       description: `A GraphQL document is only valid if all \`...Fragment\` fragment spreads refer to fragments defined in the same document.`,
+      examples: [
+        {
+          title: 'Incorrect (fragment not defined in the document)',
+          code: /* GraphQL */ `
+            query {
+              user {
+                id
+                ...UserFields
+              }
+            }
+          `,
+        },
+        {
+          title: 'Correct',
+          code: /* GraphQL */ `
+            fragment UserFields on User {
+              firstName
+              lastName
+            }
+
+            query {
+              user {
+                id
+                ...UserFields
+              }
+            }
+          `,
+        },
+        {
+          title: 'Correct (existing import to UserFields fragment)',
+          code: /* GraphQL */ `
+            #import '../UserFields.gql'
+
+            query {
+              user {
+                id
+                ...UserFields
+              }
+            }
+          `,
+        },
+      ],
     },
   }),
   validationToRule('known-type-names', 'KnownTypeNames', {

--- a/packages/plugin/src/sibling-operations.ts
+++ b/packages/plugin/src/sibling-operations.ts
@@ -13,7 +13,7 @@ import {
 } from 'graphql';
 import { ParserOptions } from './types';
 import { GraphQLConfig } from 'graphql-config';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 
 export type FragmentSource = { filePath: string; document: FragmentDefinitionNode };
 export type OperationSource = { filePath: string; document: OperationDefinitionNode };
@@ -77,7 +77,7 @@ export function getSiblingOperations(options: ParserOptions, gqlConfig: GraphQLC
   }
 
   if (!siblings && options?.operations) {
-    const loadPaths = Array.isArray(options.operations) ? options.operations : [options.operations] || [];
+    const loadPaths = Array.isArray(options.operations) ? options.operations : [options.operations];
     const loadKey = loadPaths.join(',');
 
     if (operationsCache.has(loadKey)) {

--- a/packages/plugin/tests/known-fragment-names.spec.ts
+++ b/packages/plugin/tests/known-fragment-names.spec.ts
@@ -1,0 +1,29 @@
+import { join } from 'path';
+import { GraphQLRuleTester } from '../src';
+import { GRAPHQL_JS_VALIDATIONS } from '../src/rules/graphql-js-validation';
+
+const TEST_SCHEMA = /* GraphQL */ `
+  type User {
+    id: ID!
+    firstName: String!
+  }
+
+  type Query {
+    user: User
+  }
+`;
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests('known-fragment-names', GRAPHQL_JS_VALIDATIONS['known-fragment-names'], {
+  valid: [
+    {
+      filename: join(__dirname, 'mocks/user.graphql'),
+      code: ruleTester.fromMockFile('user.graphql'),
+      parserOptions: {
+        schema: TEST_SCHEMA,
+      },
+    },
+  ],
+  invalid: [],
+});

--- a/packages/plugin/tests/mocks/user-fields.graphql
+++ b/packages/plugin/tests/mocks/user-fields.graphql
@@ -1,0 +1,4 @@
+fragment UserFields on User {
+  id
+  firstName
+}

--- a/packages/plugin/tests/mocks/user.graphql
+++ b/packages/plugin/tests/mocks/user.graphql
@@ -1,0 +1,7 @@
+#import "./user-fields.graphql"
+
+query User {
+  user {
+    ...UserFields
+  }
+}


### PR DESCRIPTION
Finally I made it work. Any feedback is welcome
Fixes https://github.com/dotansimha/graphql-eslint/issues/385

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
