### PR TITLE
fix: documents in graphql-config can be null

### DIFF
--- a/.changeset/proud-bikes-tease.md
+++ b/.changeset/proud-bikes-tease.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: documents in graphql-config can be null

--- a/packages/plugin/src/sibling-operations.ts
+++ b/packages/plugin/src/sibling-operations.ts
@@ -70,7 +70,7 @@ export function getSiblingOperations(options: ParserOptions, gqlConfig: GraphQLC
     } else {
       const projectForFile = gqlConfig.getProjectForFile(options.filePath);
 
-      if (projectForFile && projectForFile.documents.length > 0) {
+      if (projectForFile?.documents) {
         siblings = projectForFile.loadDocumentsSync(projectForFile.documents, {
           skipGraphQLImport: true,
         });


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-eslint/issues/517