### PR TITLE
4️⃣ fix false negative case in unique-fragment-name rule

### DIFF
--- a/.changeset/four-coats-vanish.md
+++ b/.changeset/four-coats-vanish.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix(siblings): return virtual path for code files instead of real path

--- a/packages/plugin/src/rules/unique-fragment-name.ts
+++ b/packages/plugin/src/rules/unique-fragment-name.ts
@@ -22,11 +22,11 @@ export const checkNode = (
   const siblings = requireSiblingsOperations(ruleName, context);
   const siblingDocuments: (FragmentSource | OperationSource)[] =
     node.kind === Kind.FRAGMENT_DEFINITION ? siblings.getFragment(documentName) : siblings.getOperation(documentName);
-  const realFilepath = getOnDiskFilepath(context.getFilename());
+  const filepath = context.getFilename();
 
   const conflictingDocuments = siblingDocuments.filter(f => {
     const isSameName = f.document.name?.value === documentName;
-    const isSamePath = normalizePath(f.filePath) === normalizePath(realFilepath);
+    const isSamePath = normalizePath(f.filePath) === normalizePath(filepath);
     return isSameName && !isSamePath;
   });
 
@@ -36,7 +36,9 @@ export const checkNode = (
       messageId,
       data: {
         documentName,
-        summary: conflictingDocuments.map(f => `\t${relative(process.cwd(), f.filePath)}`).join('\n'),
+        summary: conflictingDocuments
+          .map(f => `\t${relative(process.cwd(), getOnDiskFilepath(f.filePath))}`)
+          .join('\n'),
       },
       loc: {
         start: {

--- a/packages/plugin/tests/mocks/two-fragments-in-code-file.js
+++ b/packages/plugin/tests/mocks/two-fragments-in-code-file.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const USER_FIELDS = /* GraphQL */ `
+  fragment UserFields on User {
+    id
+    firstName
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ALL_USER_FIELDS = /* GraphQL */ `
+  fragment UserFields on User {
+    id
+    firstName
+    lastName
+  }
+`;

--- a/packages/plugin/tests/unique-fragment-name.spec.ts
+++ b/packages/plugin/tests/unique-fragment-name.spec.ts
@@ -31,7 +31,7 @@ ruleTester.runGraphQLTests('unique-fragment-name', rule, {
     {
       // Compare filepath of code as real instead of virtual with siblings
       ...SIBLING_FRAGMENTS(join(__dirname, 'mocks/unique-fragment.js')),
-      filename: join(__dirname, 'mocks/unique-fragment.js/0_document.graphql '),
+      filename: join(__dirname, 'mocks/unique-fragment.js/0_document.graphql'),
       code: /* GraphQL */ `
         fragment UserFields on User {
           id

--- a/packages/plugin/tests/unique-operation-name.spec.ts
+++ b/packages/plugin/tests/unique-operation-name.spec.ts
@@ -21,7 +21,7 @@ ruleTester.runGraphQLTests('unique-operation-name', rule, {
     {
       // Compare filepath of code as real instead of virtual with siblings
       ...SIBLING_OPERATIONS(join(__dirname, 'mocks/unique-fragment.js')),
-      filename: join(__dirname, 'mocks/unique-fragment.js/1_document.graphql '),
+      filename: join(__dirname, 'mocks/unique-fragment.js/1_document.graphql'),
       code: /* GraphQL */ `
         query User {
           user {


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-eslint/issues/515

`@graphql-tools/graphql-tag-pluck` v7 returns multiple extracted documents instead of single like in v6 so I updated `@graphql-tools` dependencies to v7 and I added support for virtual filepath for siblings