### PR TITLE
Add support for #graphql as magic comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project integrates GraphQL and ESLint, for a better developer experience.
 ## Key Features
 
 - 🚀 Integrates with ESLint core (as a ESTree parser).
-- 🚀 Works on `.graphql` files, `gql` usages and `/* GraphQL */` magic comments.
+- 🚀 Works on `.graphql` files, `gql` usages, `/* GraphQL */` and `#graphql` magic comments.
 - 🚀 Lints both GraphQL schema and GraphQL operations.
 - 🚀 Extended type info for more advanced usages
 - 🚀 Supports ESLint directives (for example: `disable-next-line`)

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -4,7 +4,7 @@ To get started with your own rules, start by understanding how [ESLint custom ru
 
 `graphql-eslint` converts the [GraphQL AST](https://graphql.org/graphql-js/language/) into [ESTree structure](https://github.com/estree/estree), so it allows you to easily travel the GraphQL AST tree easily.
 
-You can visit any GraphQL AST node in your custom rules, and report this as error. You don't need to have special handlers for code-files, since `graphql-eslint` extracts usages of `gql` and magic `/* GraphQL */` comments automatically, and runs it through the parser, and eventually it knows to adjust errors location to fit in your code files original location.
+You can visit any GraphQL AST node in your custom rules, and report this as error. You don't need to have special handlers for code-files, since `graphql-eslint` extracts usages of `gql` and magic `/* GraphQL */` or `#graphql` comments automatically, and runs it through the parser, and eventually it knows to adjust errors location to fit in your code files original location.
 
 ## Getting Started
 

--- a/packages/plugin/src/processors/code-files.ts
+++ b/packages/plugin/src/processors/code-files.ts
@@ -1,7 +1,7 @@
 import { Linter } from 'eslint';
 import { parseCode } from '@graphql-tools/graphql-tag-pluck';
 
-const RELEVANT_KEYWORDS = ['gql', 'graphql', '/* GraphQL */'];
+const RELEVANT_KEYWORDS = ['gql', 'graphql', '/* GraphQL */', '#graphql'];
 
 type Block = {
   text: string;

--- a/packages/plugin/tests/__snapshots__/parser.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/parser.spec.ts.snap
@@ -222,3 +222,245 @@ Object {
   "type": "Program",
 }
 `;
+
+exports[`Parser parseForESLint() should return ast and tokens for #graphql 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "definitions": Array [
+        Object {
+          "description": Object {
+            "block": true,
+            "gqlLocation": Object {
+              "end": 60,
+              "start": 15,
+            },
+            "kind": "StringValue",
+            "leadingComments": Array [],
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 2,
+              },
+              "source": "#graphql
+      \\"\\"\\"
+      generic query placeholder
+      \\"\\"\\"
+      type Query
+    ",
+              "start": Object {
+                "column": 7,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              15,
+              60,
+            ],
+            "rawNode": [Function],
+            "type": "StringValue",
+            "typeInfo": [Function],
+            "value": "generic query placeholder",
+          },
+          "directives": Array [],
+          "fields": Array [],
+          "gqlLocation": Object {
+            "end": 77,
+            "start": 15,
+          },
+          "interfaces": Array [],
+          "kind": "ObjectTypeDefinition",
+          "leadingComments": Array [
+            Object {
+              "type": "Block",
+              "value": "generic query placeholder",
+            },
+          ],
+          "loc": Object {
+            "end": Object {
+              "column": 12,
+              "line": 5,
+            },
+            "source": "#graphql
+      \\"\\"\\"
+      generic query placeholder
+      \\"\\"\\"
+      type Query
+    ",
+            "start": Object {
+              "column": 7,
+              "line": 2,
+            },
+          },
+          "name": Object {
+            "gqlLocation": Object {
+              "end": 77,
+              "start": 72,
+            },
+            "kind": "Name",
+            "leadingComments": Array [],
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 5,
+              },
+              "source": "#graphql
+      \\"\\"\\"
+      generic query placeholder
+      \\"\\"\\"
+      type Query
+    ",
+              "start": Object {
+                "column": 12,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              72,
+              77,
+            ],
+            "rawNode": [Function],
+            "type": "Name",
+            "typeInfo": [Function],
+            "value": "Query",
+          },
+          "range": Array [
+            15,
+            77,
+          ],
+          "rawNode": [Function],
+          "type": "ObjectTypeDefinition",
+          "typeInfo": [Function],
+        },
+      ],
+      "gqlLocation": Object {
+        "end": 82,
+        "start": 0,
+      },
+      "kind": "Document",
+      "leadingComments": Array [],
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 6,
+        },
+        "source": "#graphql
+      \\"\\"\\"
+      generic query placeholder
+      \\"\\"\\"
+      type Query
+    ",
+        "start": Object {
+          "column": 0,
+          "line": 0,
+        },
+      },
+      "range": Array [
+        0,
+        82,
+      ],
+      "rawNode": [Function],
+      "type": "Document",
+      "typeInfo": [Function],
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        8,
+      ],
+      "type": "Block",
+      "value": "graphql",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 5,
+      "line": 6,
+    },
+    "source": "#graphql
+      \\"\\"\\"
+      generic query placeholder
+      \\"\\"\\"
+      type Query
+    ",
+    "start": Object {
+      "column": 0,
+      "line": 0,
+    },
+  },
+  "range": Array [
+    0,
+    82,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        15,
+        60,
+      ],
+      "type": "BlockString",
+      "value": "generic query placeholder",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        67,
+        71,
+      ],
+      "type": "Name",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        72,
+        77,
+      ],
+      "type": "Name",
+      "value": "Query",
+    },
+  ],
+  "type": "Program",
+}
+`;

--- a/packages/plugin/tests/parser.spec.ts
+++ b/packages/plugin/tests/parser.spec.ts
@@ -14,6 +14,19 @@ describe('Parser', () => {
     expect(result.ast.tokens).toBeTruthy();
   });
 
+  it('parseForESLint() should return ast and tokens for #graphql', () => {
+    const code = `#graphql
+      """
+      generic query placeholder
+      """
+      type Query
+    `;
+
+    const result = parseForESLint(code, { filePath: 'test.graphql' });
+    expect(result.ast).toMatchSnapshot();
+    expect(result.ast.tokens).toBeTruthy();
+  });
+
   it('should throw on invalid code', () => {
     const code = 'Hello World!';
 
@@ -48,7 +61,7 @@ describe('Parser', () => {
         user(id: ID!): User!
       }
     `;
-    const code = /* GraphQL */ `
+    const code = `#graphql
       query user($id: ID!) {
         user(id: $id) {
           id

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -62,7 +62,7 @@ function generateDocs(): void {
       blocks.push(BR, `## Usage Examples`);
 
       for (const { usage, title, code } of docs.examples) {
-        const isJsCode = ['gql`', '/* GraphQL */'].some(str => code.includes(str));
+        const isJsCode = ['gql`', '/* GraphQL */', '#graphql'].some(str => code.includes(str));
         blocks.push(BR, `### ${title}`, BR, '```' + (isJsCode ? 'js' : 'graphql'));
 
         if (!isJsCode) {


### PR DESCRIPTION
## Description

This PR adds support for `#graphql` as the magic comments as used by VSCode GraphQL

Fixes https://github.com/dotansimha/graphql-eslint/issues/656

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Testcase added to check for AST and tokens similar to `/* GraphQL */` comments

**Test Environment**:
- OS: Ubuntu 20.04
- NodeJS: `v16.6.2`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes