### PR TITLE
fix: make works graphql-eslint in yarn berry

### DIFF
--- a/.changeset/metal-squids-listen.md
+++ b/.changeset/metal-squids-listen.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: make works graphql-eslint in yarn berry

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -26,6 +26,7 @@
     "prepack": "bob prepack"
   },
   "dependencies": {
+    "@babel/code-frame": "7.16.0",
     "@graphql-tools/code-file-loader": "^7.0.2",
     "@graphql-tools/graphql-tag-pluck": "^7.0.2",
     "@graphql-tools/import": "^6.3.1",
@@ -35,7 +36,6 @@
     "lodash.lowercase": "^4.3.0"
   },
   "devDependencies": {
-    "@babel/code-frame": "7.16.0",
     "@types/babel__code-frame": "7.0.3",
     "@types/eslint": "7.28.2",
     "@types/graphql-depth-limit": "1.1.3",
@@ -50,7 +50,6 @@
   "buildOptions": {
     "input": "./src/index.ts",
     "external": [
-      "@babel/code-frame",
       "eslint",
       "graphql",
       "graphql/validation/rules/ExecutableDefinitionsRule",


### PR DESCRIPTION
related https://github.com/dotansimha/graphql-eslint/issues/292#issuecomment-962125460

Currently, when trying to use @graphql-eslint on yarn berry there is an error, because `@babel/code-frame` is declared in `devDependencies` (we use `@babel/code-frame` only in `GraphQLRuleTester` but we export him also)
```sh
Oops! Something went wrong! :(

ESLint: 7.32.0

Error: Cannot read config file: /Users/dimitri/Desktop/graphql-eslint-issue-repro/.eslintrc.js
Error: @graphql-eslint/eslint-plugin tried to access @babel/code-frame, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @babel/code-frame
Required by: @graphql-eslint/eslint-plugin@virtual:28a64deb451814b2a4d09c4e73b83102a09eb40705b3643f110dd175c81a0b4d602ca2762a0264adf93e4bb998c7a32abc6c946e6ec8aadf103960b24120a9d9#npm:2.4.0 (via /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/__virtual__/@graphql-eslint-eslint-plugin-virtual-cb18878fc2/0/cache/@graphql-eslint-eslint-plugin-npm-2.4.0-05cb415ea2-8e434c2176.zip/node_modules/@graphql-eslint/eslint-plugin/)

Require stack:
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/__virtual__/@graphql-eslint-eslint-plugin-virtual-cb18878fc2/0/cache/@graphql-eslint-eslint-plugin-npm-2.4.0-05cb415ea2-8e434c2176.zip/node_modules/@graphql-eslint/eslint-plugin/index.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.eslintrc.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/@eslint-eslintrc-npm-0.4.3-ee1bbcab87-03a7704150.zip/node_modules/@eslint/eslintrc/lib/config-array-factory.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/@eslint-eslintrc-npm-0.4.3-ee1bbcab87-03a7704150.zip/node_modules/@eslint/eslintrc/lib/index.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/eslint-npm-7.32.0-e15cc6682f-cc85af9985.zip/node_modules/eslint/lib/cli-engine/cli-engine.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/eslint-npm-7.32.0-e15cc6682f-cc85af9985.zip/node_modules/eslint/lib/eslint/eslint.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/eslint-npm-7.32.0-e15cc6682f-cc85af9985.zip/node_modules/eslint/lib/eslint/index.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/eslint-npm-7.32.0-e15cc6682f-cc85af9985.zip/node_modules/eslint/lib/cli.js
- /Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/eslint-npm-7.32.0-e15cc6682f-cc85af9985.zip/node_modules/eslint/bin/eslint.js
    at Function.external_module_.Module._resolveFilename (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.pnp.cjs:13484:55)
    at Function.external_module_.Module._load (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.pnp.cjs:13283:48)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/v8-compile-cache-npm-2.3.0-961375f150-adb0a271ea.zip/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/__virtual__/@graphql-eslint-eslint-plugin-virtual-cb18878fc2/0/cache/@graphql-eslint-eslint-plugin-npm-2.4.0-05cb415ea2-8e434c2176.zip/node_modules/@graphql-eslint/eslint-plugin/index.js:19:19)
    at Module._compile (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.yarn/cache/v8-compile-cache-npm-2.3.0-961375f150-adb0a271ea.zip/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.external_module_.Module._load (/Users/dimitri/Desktop/graphql-eslint-issue-repro/.pnp.cjs:13333:14)
    at Module.require (internal/modules/cjs/loader.js:961:19)

```