### PR TITLE
fix: ignore arguments in `no-scalar-result-type-on-mutation` rule

### DIFF
--- a/.changeset/unlucky-buses-eat.md
+++ b/.changeset/unlucky-buses-eat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: ignore arguments in `no-scalar-result-type-on-mutation` rule

--- a/packages/plugin/src/rules/no-scalar-result-type-on-mutation.ts
+++ b/packages/plugin/src/rules/no-scalar-result-type-on-mutation.ts
@@ -1,4 +1,4 @@
-import { Kind, FieldDefinitionNode, isScalarType } from 'graphql';
+import { Kind, isScalarType, NameNode } from 'graphql';
 import { getLocation, requireGraphQLSchemaFromContext } from '../utils';
 import { GraphQLESLintRule } from '../types';
 import { GraphQLESTreeNode } from '../estree-parser';
@@ -40,14 +40,12 @@ const rule: GraphQLESLintRule = {
     }
     const selector = [
       `:matches(${Kind.OBJECT_TYPE_DEFINITION}, ${Kind.OBJECT_TYPE_EXTENSION})[name.value=${mutationType.name}]`,
-      '>',
-      Kind.FIELD_DEFINITION,
-      Kind.NAMED_TYPE,
+      `> ${Kind.FIELD_DEFINITION} > .gqlType ${Kind.NAME}`,
     ].join(' ');
 
     return {
-      [selector](node: GraphQLESTreeNode<FieldDefinitionNode>) {
-        const typeName = node.name.value;
+      [selector](node: GraphQLESTreeNode<NameNode>) {
+        const typeName = node.value;
         const graphQLType = schema.getType(typeName);
         if (isScalarType(graphQLType)) {
           context.report({

--- a/packages/plugin/tests/__snapshots__/no-scalar-result-type-on-mutation.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/no-scalar-result-type-on-mutation.spec.ts.snap
@@ -3,8 +3,8 @@
 exports[` 1`] = `
   1 |
   2 |         type Mutation {
-> 3 |           createUser: Boolean
-    |                       ^^^^^^^ Unexpected scalar result type "Boolean"
+> 3 |           createUser(a: ID, b: ID!, c: [ID]!, d: [ID!]!): Boolean
+    |                                                           ^^^^^^^ Unexpected scalar result type "Boolean"
   4 |         }
   5 |       
 `;

--- a/packages/plugin/tests/no-scalar-result-type-on-mutation.spec.ts
+++ b/packages/plugin/tests/no-scalar-result-type-on-mutation.spec.ts
@@ -40,9 +40,10 @@ ruleTester.runGraphQLTests('no-scalar-result-type-on-mutation', rule, {
   ],
   invalid: [
     {
+      name: 'should ignore arguments',
       ...useSchema(/* GraphQL */ `
         type Mutation {
-          createUser: Boolean
+          createUser(a: ID, b: ID!, c: [ID]!, d: [ID!]!): Boolean
         }
       `),
       errors: [{ message: 'Unexpected scalar result type "Boolean"' }],


### PR DESCRIPTION
fix https://github.com/dotansimha/graphql-eslint/issues/796