### PR TITLE
fix error report location for `graphql-js` rules

### DIFF
--- a/.changeset/cold-vans-help.md
+++ b/.changeset/cold-vans-help.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix error report location for `graphql-js` rules

--- a/packages/plugin/tests/__snapshots__/executable-definitions.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/executable-definitions.spec.ts.snap
@@ -2,5 +2,5 @@
 
 exports[` 1`] = `
 > 1 | type Query { t: String }
-    | ^ The "Query" definition is not executable.
+    | ^^^^ The "Query" definition is not executable.
 `;

--- a/packages/plugin/tests/__snapshots__/fields-on-correct-type.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/fields-on-correct-type.spec.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+> 1 | fragment UserFields on User { id bad age }
+    |                                  ^^^ Cannot query field "bad" on type "User". Did you mean "id"?
+`;
+
+exports[` 2`] = `
+  1 |
+  2 |         {
+  3 |           user {
+  4 |             id
+> 5 |             veryBad
+    |             ^^^^^^^ Cannot query field "veryBad" on type "User".
+  6 |             age
+  7 |           }
+  8 |         }
+  9 |       
+`;

--- a/packages/plugin/tests/__snapshots__/lone-schema-definition.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/lone-schema-definition.spec.ts.snap
@@ -24,7 +24,7 @@ exports[` 1`] = `
   21 |         }
   22 |
 > 23 |         schema {
-     |         ^ Must provide only one schema definition.
+     |         ^^^^^^ Must provide only one schema definition.
   24 |           query: RootQuery
   25 |           mutation: RootMutation
   26 |         }

--- a/packages/plugin/tests/__snapshots__/possible-type-extension.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/possible-type-extension.spec.ts.snap
@@ -7,7 +7,7 @@ exports[` 1`] = `
   4 |         }
   5 |
 > 6 |         extend type OtherUser {
-    |                     ^ Cannot extend type "OtherUser" because it is not defined.
+    |                     ^^^^^^^^^ Cannot extend type "OtherUser" because it is not defined.
   7 |           name: String!
   8 |         }
   9 |       

--- a/packages/plugin/tests/__snapshots__/unique-type-names.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/unique-type-names.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[` 1`] = `
   1 |
 > 2 |         type Query {
-    |              ^ There can be only one type named "Query".
+    |              ^^^^^ There can be only one type named "Query".
   3 |           foo: String
   4 |         }
   5 |

--- a/packages/plugin/tests/fields-on-correct-type.spec.ts
+++ b/packages/plugin/tests/fields-on-correct-type.spec.ts
@@ -1,0 +1,41 @@
+import { GraphQLRuleTester, rules, ParserOptions } from '../src';
+
+const parserOptions: ParserOptions = {
+  schema: /* GraphQL */ `
+    type User {
+      id: ID
+      age: Int
+    }
+
+    type Query {
+      user: User
+    }
+  `,
+};
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests('fields-on-correct-type', rules['fields-on-correct-type'], {
+  valid: [],
+  invalid: [
+    {
+      name: 'should highlight selection on single line',
+      code: 'fragment UserFields on User { id bad age }',
+      parserOptions,
+      errors: [{ message: 'Cannot query field "bad" on type "User". Did you mean "id"?' }],
+    },
+    {
+      name: 'should highlight selection on multi line',
+      code: /* GraphQL */ `
+        {
+          user {
+            id
+            veryBad
+            age
+          }
+        }
+      `,
+      parserOptions,
+      errors: [{ message: 'Cannot query field "veryBad" on type "User".' }],
+    },
+  ],
+});


### PR DESCRIPTION
fix https://github.com/dotansimha/graphql-eslint/issues/825

@dotansimha you can explore snapshots to see that now we'll have a correct error report location for `graphql-js` rules 😀. 