### PR TITLE
Ignore fragment definition in require id when available rule

### DIFF
--- a/.changeset/shy-mangos-grin.md
+++ b/.changeset/shy-mangos-grin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+feat: ignore fragments in `require-id-when-available` rule

--- a/docs/rules/require-id-when-available.md
+++ b/docs/rules/require-id-when-available.md
@@ -23,7 +23,7 @@ type User {
 }
 
 # Query
-query user {
+query {
   user {
     name
   }
@@ -42,7 +42,7 @@ type User {
 }
 
 # Query
-query user {
+query {
   user {
     id
     name

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -98,8 +98,8 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
     const isFound = (s: GraphQLESTreeNode<SelectionNode> | SelectionNode) =>
       s.kind === Kind.FIELD && idNames.includes(s.name.value);
 
-    // Do not check selections for FragmentDefinition and OperationDefinition
-    const selector = `${Kind.SELECTION_SET}[parent.kind!=/^(${Kind.FRAGMENT_DEFINITION})|${Kind.OPERATION_DEFINITION}$/]`;
+    // Skip check selections in FragmentDefinition
+    const selector = 'OperationDefinition SelectionSet[parent.kind!=OperationDefinition]';
 
     return {
       [selector](node: GraphQLESTreeNode<SelectionSetNode, true>) {

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -1,12 +1,14 @@
 import { getLocation, requireGraphQLSchemaFromContext, requireSiblingsOperations } from '../utils';
 import { GraphQLESLintRule } from '../types';
-import { GraphQLInterfaceType, GraphQLObjectType, Kind, SelectionNode } from 'graphql';
+import { GraphQLInterfaceType, GraphQLObjectType, Kind, SelectionNode, SelectionSetNode } from 'graphql';
+import { asArray } from '@graphql-tools/utils';
 import { getBaseType, GraphQLESTreeNode } from '../estree-parser';
 
-const REQUIRE_ID_WHEN_AVAILABLE = 'REQUIRE_ID_WHEN_AVAILABLE';
-const DEFAULT_ID_FIELD_NAME = 'id';
+export type RequireIdWhenAvailableRuleConfig = { fieldName: string | string[] };
 
-type RequireIdWhenAvailableRuleConfig = { fieldName: string };
+const RULE_ID = 'require-id-when-available';
+const MESSAGE_ID = 'REQUIRE_ID_WHEN_AVAILABLE';
+const DEFAULT_ID_FIELD_NAME = 'id';
 
 const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
   meta: {
@@ -14,7 +16,7 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
     docs: {
       category: 'Operations',
       description: 'Enforce selecting specific fields when they are available on the GraphQL type.',
-      url: 'https://github.com/dotansimha/graphql-eslint/blob/master/docs/rules/require-id-when-available.md',
+      url: `https://github.com/dotansimha/graphql-eslint/blob/master/docs/rules/${RULE_ID}.md`,
       requiresSchema: true,
       requiresSiblings: true,
       examples: [
@@ -28,7 +30,7 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
             }
 
             # Query
-            query user {
+            query {
               user {
                 name
               }
@@ -45,7 +47,7 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
             }
 
             # Query
-            query user {
+            query {
               user {
                 id
                 name
@@ -57,7 +59,7 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
       recommended: true,
     },
     messages: {
-      [REQUIRE_ID_WHEN_AVAILABLE]: [
+      [MESSAGE_ID]: [
         `Field {{ fieldName }} must be selected when it's available on a type. Please make sure to include it in your selection set!`,
         `If you are using fragments, make sure that all used fragments {{ checkedFragments }}specifies the field {{ fieldName }}.`,
       ].join('\n'),
@@ -88,21 +90,23 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
     },
   },
   create(context) {
-    requireGraphQLSchemaFromContext('require-id-when-available', context);
-    const siblings = requireSiblingsOperations('require-id-when-available', context);
+    requireGraphQLSchemaFromContext(RULE_ID, context);
+    const siblings = requireSiblingsOperations(RULE_ID, context);
     const { fieldName = DEFAULT_ID_FIELD_NAME } = context.options[0] || {};
-    const idNames = Array.isArray(fieldName) ? fieldName : [fieldName];
+    const idNames = asArray(fieldName);
 
     const isFound = (s: GraphQLESTreeNode<SelectionNode> | SelectionNode) =>
       s.kind === Kind.FIELD && idNames.includes(s.name.value);
 
+    // Do not check selections for FragmentDefinition and OperationDefinition
+    const selector = `${Kind.SELECTION_SET}[parent.kind!=/^(${Kind.FRAGMENT_DEFINITION})|${Kind.OPERATION_DEFINITION}$/]`;
+
     return {
-      SelectionSet(node) {
+      [selector](node: GraphQLESTreeNode<SelectionSetNode, true>) {
         const typeInfo = node.typeInfo();
         if (!typeInfo.gqlType) {
           return;
         }
-
         const rawType = getBaseType(typeInfo.gqlType);
         const isObjectType = rawType instanceof GraphQLObjectType;
         const isInterfaceType = rawType instanceof GraphQLInterfaceType;
@@ -115,47 +119,43 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
         if (!hasIdFieldInType) {
           return;
         }
-
         const checkedFragmentSpreads = new Set<string>();
-        let found = false;
 
         for (const selection of node.selections) {
           if (isFound(selection)) {
-            found = true;
-          } else if (selection.kind === Kind.INLINE_FRAGMENT) {
-            found = selection.selectionSet?.selections.some(s => isFound(s));
-          } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+            return;
+          }
+          if (selection.kind === Kind.INLINE_FRAGMENT && selection.selectionSet.selections.some(isFound)) {
+            return;
+          }
+          if (selection.kind === Kind.FRAGMENT_SPREAD) {
             const [foundSpread] = siblings.getFragment(selection.name.value);
-
             if (foundSpread) {
               checkedFragmentSpreads.add(foundSpread.document.name.value);
-              found = foundSpread.document.selectionSet?.selections.some(s => isFound(s));
+              if (foundSpread.document.selectionSet.selections.some(isFound)) {
+                return;
+              }
             }
-          }
-
-          if (found) {
-            break;
           }
         }
 
         const { parent } = node as any;
         const hasIdFieldInInterfaceSelectionSet =
-          parent &&
-          parent.kind === Kind.INLINE_FRAGMENT &&
-          parent.parent &&
-          parent.parent.kind === Kind.SELECTION_SET &&
-          parent.parent.selections.some(s => isFound(s));
-
-        if (!found && !hasIdFieldInInterfaceSelectionSet) {
-          context.report({
-            loc: getLocation(node.loc),
-            messageId: REQUIRE_ID_WHEN_AVAILABLE,
-            data: {
-              checkedFragments: checkedFragmentSpreads.size === 0 ? '' : `(${[...checkedFragmentSpreads].join(', ')}) `,
-              fieldName: idNames.map(name => `"${name}"`).join(' or '),
-            },
-          });
+          parent?.kind === Kind.INLINE_FRAGMENT &&
+          parent.parent?.kind === Kind.SELECTION_SET &&
+          parent.parent.selections.some(isFound);
+        if (hasIdFieldInInterfaceSelectionSet) {
+          return;
         }
+
+        context.report({
+          loc: getLocation(node.loc),
+          messageId: MESSAGE_ID,
+          data: {
+            checkedFragments: checkedFragmentSpreads.size === 0 ? '' : `(${[...checkedFragmentSpreads].join(', ')}) `,
+            fieldName: idNames.map(name => `"${name}"`).join(' or '),
+          },
+        });
       },
     };
   },

--- a/packages/plugin/tests/__snapshots__/require-id-when-available.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/require-id-when-available.spec.ts.snap
@@ -1,25 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[` 1`] = `
-> 1 | query { hasId { name } }
-    |               ^ Field "id" must be selected when it's available on a type. Please make sure to include it in your selection set!
+> 1 | { hasId { name } }
+    |         ^ Field "id" must be selected when it's available on a type. Please make sure to include it in your selection set!
 If you are using fragments, make sure that all used fragments specifies the field "id".
 `;
 
 exports[` 2`] = `
-> 1 | query { hasId { id } }
-    |               ^ Field "name" must be selected when it's available on a type. Please make sure to include it in your selection set!
+> 1 | { hasId { id } }
+    |         ^ Field "name" must be selected when it's available on a type. Please make sure to include it in your selection set!
 If you are using fragments, make sure that all used fragments specifies the field "name".
 `;
 
 exports[` 3`] = `
-  1 |
-  2 |         query {
-> 3 |           hasId {
-    |                 ^ Field "id" or "_id" must be selected when it's available on a type. Please make sure to include it in your selection set!
+> 1 | { hasId { name } }
+    |         ^ Field "id" or "_id" must be selected when it's available on a type. Please make sure to include it in your selection set!
 If you are using fragments, make sure that all used fragments specifies the field "id" or "_id".
-  4 |             name
-  5 |           }
-  6 |         }
-  7 |       
 `;

--- a/packages/plugin/tests/require-id-when-available.spec.ts
+++ b/packages/plugin/tests/require-id-when-available.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/require-id-when-available';
+import rule, { RequireIdWhenAvailableRuleConfig } from '../src/rules/require-id-when-available';
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {
@@ -38,64 +38,62 @@ const TEST_SCHEMA = /* GraphQL */ `
   }
 `;
 
-const WITH_SCHEMA = {
-  parserOptions: <ParserOptions>{
-    schema: TEST_SCHEMA,
-    operations: /* GraphQL */ `
-      fragment HasIdFields on HasId {
-        id
-      }
-    `,
-  },
+const parserOptions: ParserOptions = {
+  schema: TEST_SCHEMA,
+  operations: 'fragment HasIdFields on HasId { id }',
 };
+
 const ruleTester = new GraphQLRuleTester();
 
-ruleTester.runGraphQLTests('require-id-when-available', rule, {
+ruleTester.runGraphQLTests<[RequireIdWhenAvailableRuleConfig]>('require-id-when-available', rule, {
   valid: [
-    { ...WITH_SCHEMA, code: `query { noId { name } }` },
-    { ...WITH_SCHEMA, code: `query { hasId { id name } }` },
-    { ...WITH_SCHEMA, code: `query { hasId { ...HasIdFields } }` },
-    { ...WITH_SCHEMA, code: `query { vehicles { id ...on Car { id mileage } } }` },
-    { ...WITH_SCHEMA, code: `query { vehicles { ...on Car { id mileage } } }` },
-    { ...WITH_SCHEMA, code: `query { flying { ...on Bird { id } } }` },
     {
-      ...WITH_SCHEMA,
-      code: `query { hasId { name } }`,
+      parserOptions,
+      name: 'should ignore fragments',
+      code: 'fragment Test on HasId { name }',
+    },
+    { parserOptions, code: '{ noId { name } }' },
+    { parserOptions, code: '{ hasId { id name } }' },
+    {
+      parserOptions,
+      name: 'should find id in fragment',
+      code: '{ hasId { ...HasIdFields } }'
+    },
+    { parserOptions, code: '{ vehicles { id ...on Car { id mileage } } }' },
+    { parserOptions, code: '{ vehicles { ...on Car { id mileage } } }' },
+    { parserOptions, code: '{ flying { ...on Bird { id } } }' },
+    {
+      parserOptions,
+      code: '{ hasId { name } }',
       options: [{ fieldName: 'name' }],
     },
     {
-      ...WITH_SCHEMA,
-      code: `query { vehicles { id ...on Car { mileage } } }`,
+      parserOptions,
+      code: '{ vehicles { id ...on Car { mileage } } }',
     },
     {
-      ...WITH_SCHEMA,
+      parserOptions,
       name: 'support multiple id field names',
-      code: `query { hasId { _id } }`,
+      code: '{ hasId { _id } }',
       options: [{ fieldName: ['id', '_id'] }],
     },
   ],
   invalid: [
     {
-      ...WITH_SCHEMA,
-      code: `query { hasId { name } }`,
+      parserOptions,
+      code: '{ hasId { name } }',
       errors: [{ messageId: 'REQUIRE_ID_WHEN_AVAILABLE' }],
     },
     {
-      ...WITH_SCHEMA,
-      code: `query { hasId { id } }`,
+      parserOptions,
+      code: '{ hasId { id } }',
       options: [{ fieldName: 'name' }],
       errors: [{ messageId: 'REQUIRE_ID_WHEN_AVAILABLE' }],
     },
     {
-      ...WITH_SCHEMA,
+      parserOptions,
       name: 'support multiple id field names',
-      code: /* GraphQL */ `
-        query {
-          hasId {
-            name
-          }
-        }
-      `,
+      code: '{ hasId { name } }',
       options: [{ fieldName: ['id', '_id'] }],
       errors: [{ messageId: 'REQUIRE_ID_WHEN_AVAILABLE' }],
     },


### PR DESCRIPTION
fix https://github.com/dotansimha/graphql-eslint/issues/731
I think it's reasonable we need to check selections only in operations but not in fragment definition
also, I ignore selections where the parent kind is OperationDefinition node as it's redundant check