### PR TITLE
fix: find graphqlrc files relative to linted file

### DIFF
--- a/.changeset/relative-graphqlrc.md
+++ b/.changeset/relative-graphqlrc.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+fix: find graphqlrc files relative to linted file

--- a/packages/plugin/src/graphql-config.ts
+++ b/packages/plugin/src/graphql-config.ts
@@ -1,6 +1,7 @@
 import { GraphQLConfig, GraphQLExtensionDeclaration, loadConfigSync, SchemaPointer } from 'graphql-config';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { ParserOptions } from './types';
+import { dirname } from 'path';
 
 let graphQLConfig: GraphQLConfig;
 
@@ -14,6 +15,8 @@ export function loadGraphQLConfig(options: ParserOptions): GraphQLConfig {
   const onDiskConfig = options.skipGraphQLConfig
     ? null
     : loadConfigSync({
+        // load config relative to the file being linted
+        rootDir: options.filePath ? dirname(options.filePath) : undefined,
         throwOnEmpty: false,
         throwOnMissing: false,
         extensions: [addCodeFileLoaderExtension],

--- a/packages/plugin/tests/mocks/using-config/.graphqlrc
+++ b/packages/plugin/tests/mocks/using-config/.graphqlrc
@@ -1,0 +1,1 @@
+schema: ./schema-in-config.graphql

--- a/packages/plugin/tests/mocks/using-config/schema-in-config.graphql
+++ b/packages/plugin/tests/mocks/using-config/schema-in-config.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}

--- a/packages/plugin/tests/mocks/using-config/test.graphql
+++ b/packages/plugin/tests/mocks/using-config/test.graphql
@@ -1,0 +1,3 @@
+query {
+  hello
+}

--- a/packages/plugin/tests/schema.spec.ts
+++ b/packages/plugin/tests/schema.spec.ts
@@ -146,11 +146,28 @@ describe('schema', () => {
       expect(consoleError.mock.calls[0][2]).toMatch(
         'Unable to find any GraphQL type definitions for the following pointers'
       );
-    })
+    });
 
     it('should not log second time error from same schema', () => {
       expect(getSchema(undefined, gqlConfig)).toBe(null);
       expect(consoleError).toHaveBeenCalledTimes(1);
-    })
+    });
+  });
+
+  it('should load the graphql-config rc file relative to the linted file', () => {
+    const schema = resolve(__dirname, 'mocks/using-config/schema.graphql');
+    const gqlConfig = loadGraphQLConfig({
+      schema,
+      filePath: resolve(__dirname, 'mocks/using-config/test.graphql'),
+    });
+
+    const graphQLSchema = getSchema({ schema }, gqlConfig);
+    expect(graphQLSchema).toBeInstanceOf(GraphQLSchema);
+    const sdlString = printSchema(graphQLSchema);
+    expect(sdlString.trim()).toMatchInlineSnapshot(`
+      type Query {
+        hello: String
+      }
+    `);
   });
 });


### PR DESCRIPTION


## Description

Before this change, `loadConfigSync` from graphql-config would use `process.cwd` to find any .graphqlrc files.

With a project like this:
```
project/
- packages/
  - app/
    - schema.graphql
    - .eslintrc
    - .graphqlrc
    - documents/
      - operation.graphql
```

the VSCode Eslint plugin throws an error about not being able to find the schema.graphql file when linting the operation.graphql.

This change passes in the [`rootDir` option](https://graphql-config.com/load-config#rootdir) to `loadConfigSync` using the directory of the linted file. This will allow the .graphqlrc file to live in subfolders of the open project.

Fixes #899

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://stackblitz.com/edit/node-6fhvcm?file=README.md

## How Has This Been Tested?

Unit tests, but I also installed my local copy in a separate project using `"file:"` in package.json to verify that it works with the VSCode ESLint plugin.

**Test Environment**:
- OS: macos monterey
- `@graphql-eslint/eslint-plugin@3.6.0`:
- NodeJS: 14.16.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **not applicable**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules - **not applicable**

Thank you for your review!
